### PR TITLE
feat: generate dnscheck observations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ To get yourself started with using this repo, run the following:
 ```
 poetry install
 mkdir output/
-poetry run python oonidata/processing.py --csv-dir output/
+poetry run python oonidata/processing.py --csv-dir output/ --geoip-dir ../historical-geoip/country-asn-databases --asn-map ../historical-geoip/as-orgs/all_as_org_map.json
 ```
 
 ## Architecture overview

--- a/Readme.md
+++ b/Readme.md
@@ -119,6 +119,22 @@ Once the day is finished, we can re-run the verdict generation using the batch
 workflow and mark for deletion all the verdicts generated in streaming mode, leading
 to an eventual consistency.
 
+The possible outcomes for the verdict are:
+
+* dns.blockpage
+* dns.bogon
+* dns.nxdomain
+* dns.{failure}
+* dns.inconsistent
+* tls.mitm
+* tls.{failure}
+* http.{failure}
+* https.{failure}
+* http.blockpage
+* http.bodydiff
+* tcp.{failure}
+
+
 ### Current pipeline
 
 This section documents the current [ooni/pipeline](https://github.com/ooni/pipeline)

--- a/oonidata/dataformat.py
+++ b/oonidata/dataformat.py
@@ -166,7 +166,7 @@ class DNSQuery:
     dial_id: Optional[int]
     engine: Optional[str]
     failure: Failure
-    hostname: Optional[str]
+    hostname: str
     query_type: str
 
     # XXX: Map resolver_hostname and resolver_port to this

--- a/oonidata/dataformat.py
+++ b/oonidata/dataformat.py
@@ -284,6 +284,25 @@ class WebConnectivityTestKeys(BaseTestKeys):
 class WebConnectivity(BaseMeasurement):
     test_keys: WebConnectivityTestKeys
 
+@dataclass
+class URLGetterTestKeys(BaseTestKeys):
+    failure: Failure
+    socksproxy: Optional[str]
+    tls_handshakes: Optional[List[TLSHandshake]]
+    network_events: Optional[List[NetworkEvent]]
+    queries: Optional[List[DNSQuery]]
+    tcp_connect: Optional[List[TCPConnect]]
+    requests: Optional[List[HTTPTransaction]]
+
+@dataclass
+class DNSCheckTestKeys(BaseTestKeys):
+    bootstrap: Optional[URLGetterTestKeys]
+    bootstrap_failure: Optional[str]
+    lookups: dict[str, URLGetterTestKeys]
+
+@dataclass
+class DNSCheck(BaseMeasurement):
+    test_keys: DNSCheckTestKeys
 
 @dataclass
 class TorTestTarget:
@@ -309,7 +328,11 @@ class Tor(BaseMeasurement):
     test_keys: TorTestKeys
 
 
-nettest_dataformats = {"web_connectivity": WebConnectivity, "tor": Tor}
+nettest_dataformats = {
+    "web_connectivity": WebConnectivity, 
+    "tor": Tor,
+    "dnscheck": DNSCheck
+}
 
 
 def load_measurement(raw: bytes) -> BaseMeasurement:

--- a/oonidata/datautils.py
+++ b/oonidata/datautils.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, date, timedelta
 from typing import List, Any
 from dataclasses import dataclass
@@ -14,9 +15,12 @@ from cryptography.hazmat.primitives import hashes
 
 from oonidata.dataformat import HeadersListBytes, BinaryData
 
+log = logging.getLogger("oonidata.datautils")
+
 META_TITLE_REGEXP = re.compile(
     b'<meta.*?property="og:title".*?content="(.*?)"', re.IGNORECASE | re.DOTALL
 )
+
 
 def guess_decode(s: bytes) -> str:
     """
@@ -27,7 +31,9 @@ def guess_decode(s: bytes) -> str:
             return s.decode(encoding)
         except UnicodeDecodeError:
             pass
+    log.warning(f"unable to decode '{s}'")
     return s.decode("ascii", "ignore")
+
 
 def get_html_meta_title(body: bytes) -> str:
     m = META_TITLE_REGEXP.search(body, re.IGNORECASE | re.DOTALL)
@@ -213,7 +219,7 @@ def get_alternative_names(cert: x509.Certificate) -> List[str]:
         ext = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
-        san_ext: x509.SubjectAlternativeName = ext.value # type: ignore
+        san_ext: x509.SubjectAlternativeName = ext.value  # type: ignore
         return san_ext.get_values_for_type(x509.DNSName)
     except x509.ExtensionNotFound:
         return []

--- a/oonidata/datautils.py
+++ b/oonidata/datautils.py
@@ -18,22 +18,32 @@ META_TITLE_REGEXP = re.compile(
     b'<meta.*?property="og:title".*?content="(.*?)"', re.IGNORECASE | re.DOTALL
 )
 
+def guess_decode(s: bytes) -> str:
+    """
+    best effort decoding of a string of bytes
+    """
+    for encoding in ("ascii", "utf-8", "latin1"):
+        try:
+            return s.decode(encoding)
+        except UnicodeDecodeError:
+            pass
+    return s.decode("ascii", "ignore")
 
-def get_html_meta_title(body: bytes) -> bytes:
+def get_html_meta_title(body: bytes) -> str:
     m = META_TITLE_REGEXP.search(body, re.IGNORECASE | re.DOTALL)
     if m:
-        return m.group(1)
-    return b""
+        return guess_decode(m.group(1))
+    return ""
 
 
 TITLE_REGEXP = re.compile(b"<title.*?>(.*?)</title>", re.IGNORECASE | re.DOTALL)
 
 
-def get_html_title(body: bytes) -> bytes:
+def get_html_title(body: bytes) -> str:
     m = META_TITLE_REGEXP.search(body, re.IGNORECASE | re.DOTALL)
     if m:
-        return m.group(1)
-    return b""
+        return guess_decode(m.group(1))
+    return ""
 
 
 def get_first_http_header(

--- a/oonidata/observations.py
+++ b/oonidata/observations.py
@@ -221,12 +221,16 @@ class HTTPObservation(Observation):
         )
 
         try:
-            prev_request = requests_list[idx + 1] # type: ignore
+            # We add type: ignore in here, because requests_lists is an optional
+            # field and the fact it might not be defined is handled by the
+            # except block below, yet pylint is not able to figure that out.
+            # TODO: maybe refactor this handle it better by checking if these are defined
+            prev_request = requests_list[idx + 1]  # type: ignore
             prev_location = get_first_http_header(
-                "location", prev_request.response.headers_list_bytes or [] # type: ignore
+                "location", prev_request.response.headers_list_bytes or []  # type: ignore
             ).decode("utf-8")
             if prev_location == hrro.request_url:
-                hrro.request_redirect_from = prev_request.request.url # type: ignore
+                hrro.request_redirect_from = prev_request.request.url  # type: ignore
         except (IndexError, UnicodeDecodeError, AttributeError):
             pass
         return hrro
@@ -309,6 +313,9 @@ class DNSObservation(Observation):
             dnso.answer = answer.hostname
 
         if answer.ipv4 or answer.ipv6:
+            # This is guaranteed to be the correct type since we set it's value
+            # based on answer.ipv4 or answer.ipv6 being set in the previous
+            # blocks
             answer_meta = netinfodb.lookup_ip(dnso.timestamp, dnso.answer)  # type: ignore
             if answer_meta:
                 dnso.answer_asn = answer_meta.as_info.asn
@@ -316,7 +323,7 @@ class DNSObservation(Observation):
                 dnso.answer_as_org_name = answer_meta.as_info.as_org_name
                 dnso.answer_cc = answer_meta.cc
 
-        matched_fingerprint = fingerprintdb.match_dns(dnso.answer) # type: ignore
+        matched_fingerprint = fingerprintdb.match_dns(dnso.answer)
         if matched_fingerprint:
             dnso.fingerprint_id = matched_fingerprint.name
             if matched_fingerprint.expected_countries:

--- a/oonidata/observations.py
+++ b/oonidata/observations.py
@@ -139,8 +139,8 @@ class HTTPObservation(Observation):
 
     response_status_code: Optional[int] = None
     # response_headers_list: Optional[List[Tuple[str, bytes]]]
-    response_header_location: Optional[str] = None
-    response_header_server: Optional[str] = None
+    response_header_location: Optional[bytes] = None
+    response_header_server: Optional[bytes] = None
     request_redirect_from: Optional[str] = None
     request_body_is_truncated: Optional[bool] = None
 
@@ -168,11 +168,11 @@ class HTTPObservation(Observation):
         hrro = HTTPObservation(
             observation_id=f"{msmt.measurement_uid}{idx}",
             request_url=http_transaction.request.url,
-            domain_name=parsed_url.hostname,
+            domain_name=parsed_url.hostname or "",
             request_is_encrypted=parsed_url.scheme == "https",
             request_body_is_truncated=http_transaction.request.body_is_truncated,
             # hrro.request_headers_list = http_transaction.request.headers_list_bytes
-            request_method=http_transaction.request.method,
+            request_method=http_transaction.request.method or "",
             request_body_length=len(http_transaction.request.body_bytes)
             if http_transaction.request.body_bytes
             else 0,
@@ -214,19 +214,19 @@ class HTTPObservation(Observation):
         # hrro.response_headers_list = http_transaction.response.headers_list_bytes
 
         hrro.response_header_location = get_first_http_header(
-            "location", http_transaction.response.headers_list_bytes
+            "location", http_transaction.response.headers_list_bytes or []
         )
         hrro.response_header_server = get_first_http_header(
-            "server", http_transaction.response.headers_list_bytes
+            "server", http_transaction.response.headers_list_bytes or []
         )
 
         try:
-            prev_request = requests_list[idx + 1]
+            prev_request = requests_list[idx + 1] # type: ignore
             prev_location = get_first_http_header(
-                "location", prev_request.response.headers_list_bytes
+                "location", prev_request.response.headers_list_bytes or [] # type: ignore
             ).decode("utf-8")
             if prev_location == hrro.request_url:
-                hrro.request_redirect_from = prev_request.request.url
+                hrro.request_redirect_from = prev_request.request.url # type: ignore
         except (IndexError, UnicodeDecodeError, AttributeError):
             pass
         return hrro
@@ -305,14 +305,14 @@ class DNSObservation(Observation):
             dnso.answer = answer.hostname
 
         if answer.ipv4 or answer.ipv6:
-            answer_meta = netinfodb.lookup_ip(dnso.timestamp, dnso.answer)
+            answer_meta = netinfodb.lookup_ip(dnso.timestamp, dnso.answer)  # type: ignore
             if answer_meta:
                 dnso.answer_asn = answer_meta.as_info.asn
                 dnso.answer_as_cc = answer_meta.as_info.as_cc
                 dnso.answer_as_org_name = answer_meta.as_info.as_org_name
                 dnso.answer_cc = answer_meta.cc
 
-        matched_fingerprint = fingerprintdb.match_dns(dnso.answer)
+        matched_fingerprint = fingerprintdb.match_dns(dnso.answer) # type: ignore
         if matched_fingerprint:
             dnso.fingerprint_id = matched_fingerprint.name
             if matched_fingerprint.expected_countries:

--- a/oonidata/observations.py
+++ b/oonidata/observations.py
@@ -259,6 +259,8 @@ class DNSObservation(Observation):
 
     query_type: str
     failure: Failure
+    engine: Optional[str]
+    engine_resolver_address: Optional[str]
 
     answer_type: Optional[str] = None
     answer: Optional[str] = None
@@ -284,6 +286,8 @@ class DNSObservation(Observation):
     ) -> "DNSObservation":
         dnso = DNSObservation(
             observation_id=f"{msmt.measurement_uid}{idx}",
+            engine=query.engine,
+            engine_resolver_address=query.resolver_address,
             query_type=query.query_type,
             domain_name=query.hostname,
             failure=normalize_failure(query.failure),

--- a/oonidata/processing.py
+++ b/oonidata/processing.py
@@ -332,7 +332,7 @@ nettest_processors = {
 }
 
 
-def process_day(db: DatabaseConnection, fingerprintdb : FingerprintDB, netinfodb : NetinfoDB, day: date, testnames=[], start_at_idx=0):
+def process_day(db: DatabaseConnection, fingerprintdb : FingerprintDB, netinfodb : NetinfoDB, day: date, testnames=[], start_at_idx=0, skip_verdicts=False):
 
     with tqdm(unit="B", unit_scale=True) as pbar:
         for idx, raw_msmt in enumerate(
@@ -363,7 +363,7 @@ def process_day(db: DatabaseConnection, fingerprintdb : FingerprintDB, netinfodb
                 log.error(f"Wrote bad msmt to: ./bad_msmts.jsonl")
                 raise exc
 
-    if isinstance(db, ClickhouseConnection):
+    if not skip_verdicts:
         write_verdicts_to_db(
             db,
             generate_website_verdicts(
@@ -415,6 +415,7 @@ if __name__ == "__main__":
         default=0,
     )
     parser.add_argument("--only-verdicts", action="store_true")
+    parser.add_argument("--skip-verdicts", action="store_true")
     args = parser.parse_args()
 
     fingerprintdb = FingerprintDB()
@@ -447,4 +448,4 @@ if __name__ == "__main__":
     testnames = []
     if args.testname:
         testnames = [args.testname]
-    process_day(db, fingerprintdb, netinfodb, args.day, testnames=testnames, start_at_idx=args.start_at_idx)
+    process_day(db, fingerprintdb, netinfodb, args.day, testnames=testnames, start_at_idx=args.start_at_idx, skip_verdicts=args.skip_verdicts)

--- a/oonidata/processing.py
+++ b/oonidata/processing.py
@@ -445,7 +445,11 @@ if __name__ == "__main__":
         )
         sys.exit(0)
 
+    skip_verdicts = args.skip_verdicts
+    if not isinstance(db, ClickhouseConnection):
+        skip_verdicts = True
+
     testnames = []
     if args.testname:
         testnames = [args.testname]
-    process_day(db, fingerprintdb, netinfodb, args.day, testnames=testnames, start_at_idx=args.start_at_idx, skip_verdicts=args.skip_verdicts)
+    process_day(db, fingerprintdb, netinfodb, args.day, testnames=testnames, start_at_idx=args.start_at_idx, skip_verdicts=skip_verdicts)


### PR DESCRIPTION
Add support for generating observations for DNS check.

As part of this PR I have also made some smaller improvements to ooni/data overall, which includes:
* Guessing the encoding of HTML titles and bodies
* Improvements to typing
* Additions to the Readme file

Nice things to have that are currently missing are:
* Supporting extracting metadata from the network_events specific to dnscheck, for example the DNS lookup time (though this could eventually become part of the base formats too)

Open questions/things to figure out:
* Do we need any additional metadata inside of the tables to make the task of analysing these results easier?

Closes https://github.com/ooni/backend/issues/606