### PR TITLE
More observations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/data/historical-geoip"]
+	path = tests/data/historical-geoip
+	url = git@github.com:ooni/historical-geoip.git

--- a/oonidata/dataformat.py
+++ b/oonidata/dataformat.py
@@ -128,7 +128,7 @@ class HTTPBase:
 class HTTPRequest(HTTPBase):
     url: str
     method: Optional[str]
-    tor: TorInfo
+    tor: Optional[TorInfo]
     x_transport: Optional[str] = "tcp"
 
 

--- a/oonidata/dataformat.py
+++ b/oonidata/dataformat.py
@@ -284,6 +284,25 @@ class WebConnectivityTestKeys(BaseTestKeys):
 class WebConnectivity(BaseMeasurement):
     test_keys: WebConnectivityTestKeys
 
+@dataclass
+class URLGetterTestKeys(BaseTestKeys):
+    failure: Failure
+    socksproxy: Optional[str]
+    tls_handshakes: Optional[List[TLSHandshake]]
+    network_events: Optional[List[NetworkEvent]]
+    queries: Optional[List[DNSQuery]]
+    tcp_connect: Optional[List[TCPConnect]]
+    requests: Optional[List[HTTPTransaction]]
+
+@dataclass
+class DNSCheckTestKeys(BaseTestKeys):
+    bootstrap: Optional[URLGetterTestKeys]
+    bootstrap_failure: Optional[str]
+    lookups: dict[str, URLGetterTestKeys]
+
+@dataclass
+class DNSCheck(BaseMeasurement):
+    test_keys: DNSCheckTestKeys
 
 @dataclass
 class TorTestTarget:
@@ -309,7 +328,11 @@ class Tor(BaseMeasurement):
     test_keys: TorTestKeys
 
 
-nettest_dataformats = {"web_connectivity": WebConnectivity, "tor": Tor}
+nettest_dataformats = {
+    "web_connectivity": WebConnectivity, 
+    "tor": Tor,
+    "dnscheck": DNSCheck
+}
 
 
 def load_measurement(raw: bytes) -> BaseMeasurement:

--- a/oonidata/dataformat.py
+++ b/oonidata/dataformat.py
@@ -19,6 +19,7 @@ from dacite.core import from_dict
 
 from oonidata.utils import trivial_id
 
+
 @dataclass
 class BinaryData:
     format: str
@@ -27,6 +28,7 @@ class BinaryData:
 
 MaybeBinaryData = Union[str, BinaryData, None]
 Failure = Optional[str]
+
 
 def guess_decode(s: bytes) -> str:
     """
@@ -38,6 +40,7 @@ def guess_decode(s: bytes) -> str:
         except UnicodeDecodeError:
             pass
     return s.decode("ascii", "ignore")
+
 
 def maybe_binary_data_to_bytes(mbd: MaybeBinaryData) -> bytes:
     if isinstance(mbd, BinaryData):
@@ -116,9 +119,7 @@ class HTTPBase:
                 assert len(header_pair) == 2, "Inconsistent header"
                 header_name = guess_decode(maybe_binary_data_to_bytes(header_pair[0]))
                 header_value = maybe_binary_data_to_bytes(header_pair[1])
-                self.headers_list_bytes.append(
-                    (header_name, header_value)
-                )
+                self.headers_list_bytes.append((header_name, header_value))
 
         if self.body:
             self.body_bytes = maybe_binary_data_to_bytes(self.body)
@@ -288,6 +289,7 @@ class WebConnectivityTestKeys(BaseTestKeys):
 class WebConnectivity(BaseMeasurement):
     test_keys: WebConnectivityTestKeys
 
+
 @dataclass
 class URLGetterTestKeys(BaseTestKeys):
     failure: Failure
@@ -298,15 +300,18 @@ class URLGetterTestKeys(BaseTestKeys):
     tcp_connect: Optional[List[TCPConnect]]
     requests: Optional[List[HTTPTransaction]]
 
+
 @dataclass
 class DNSCheckTestKeys(BaseTestKeys):
     bootstrap: Optional[URLGetterTestKeys]
     bootstrap_failure: Optional[str]
     lookups: dict[str, URLGetterTestKeys]
 
+
 @dataclass
 class DNSCheck(BaseMeasurement):
     test_keys: DNSCheckTestKeys
+
 
 @dataclass
 class TorTestTarget:
@@ -333,9 +338,9 @@ class Tor(BaseMeasurement):
 
 
 nettest_dataformats = {
-    "web_connectivity": WebConnectivity, 
+    "web_connectivity": WebConnectivity,
     "tor": Tor,
-    "dnscheck": DNSCheck
+    "dnscheck": DNSCheck,
 }
 
 

--- a/oonidata/dataformat.py
+++ b/oonidata/dataformat.py
@@ -7,7 +7,7 @@ See:
 
 - https://github.com/ooni/spec/tree/master/nettests
 """
-
+import logging
 import ujson
 
 from base64 import b64decode
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from dacite.core import from_dict
 
 from oonidata.utils import trivial_id
+
+log = logging.getLogger("oonidata.dataformat")
 
 
 @dataclass
@@ -39,6 +41,7 @@ def guess_decode(s: bytes) -> str:
             return s.decode(encoding)
         except UnicodeDecodeError:
             pass
+    log.warning(f"unable to decode '{s}'")
     return s.decode("ascii", "ignore")
 
 

--- a/oonidata/datautils.py
+++ b/oonidata/datautils.py
@@ -12,22 +12,11 @@ from cryptography.x509.oid import ExtensionOID, NameOID
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 
-from oonidata.dataformat import HeadersListBytes, BinaryData
+from oonidata.dataformat import HeadersListBytes, BinaryData, guess_decode
 
 META_TITLE_REGEXP = re.compile(
     b'<meta.*?property="og:title".*?content="(.*?)"', re.IGNORECASE | re.DOTALL
 )
-
-def guess_decode(s: bytes) -> str:
-    """
-    best effort decoding of a string of bytes
-    """
-    for encoding in ("ascii", "utf-8", "latin1"):
-        try:
-            return s.decode(encoding)
-        except UnicodeDecodeError:
-            pass
-    return s.decode("ascii", "ignore")
 
 def get_html_meta_title(body: bytes) -> str:
     m = META_TITLE_REGEXP.search(body, re.IGNORECASE | re.DOTALL)

--- a/oonidata/datautils.py
+++ b/oonidata/datautils.py
@@ -14,9 +14,11 @@ from cryptography.hazmat.primitives import hashes
 
 from oonidata.dataformat import HeadersListBytes, BinaryData, guess_decode
 
+
 META_TITLE_REGEXP = re.compile(
     b'<meta.*?property="og:title".*?content="(.*?)"', re.IGNORECASE | re.DOTALL
 )
+
 
 def get_html_meta_title(body: bytes) -> str:
     m = META_TITLE_REGEXP.search(body, re.IGNORECASE | re.DOTALL)
@@ -202,7 +204,7 @@ def get_alternative_names(cert: x509.Certificate) -> List[str]:
         ext = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
-        san_ext: x509.SubjectAlternativeName = ext.value # type: ignore
+        san_ext: x509.SubjectAlternativeName = ext.value  # type: ignore
         return san_ext.get_values_for_type(x509.DNSName)
     except x509.ExtensionNotFound:
         return []

--- a/oonidata/db/create_tables.py
+++ b/oonidata/db/create_tables.py
@@ -16,7 +16,7 @@ def typing_to_clickhouse(t: Any) -> str:
     if t == str:
         return "String"
 
-    if t == Optional[str]:
+    if t == Optional[str] or t == Optional[bytes]:
         return "Nullable(String)"
 
     if t == int:
@@ -60,11 +60,11 @@ def typing_to_clickhouse(t: Any) -> str:
     raise Exception(f"Unhandled type {t}")
 
 
-def create_query_for_observation(obs_class: Type[Observation]) -> str:
+def create_query_for_observation(obs_class: Type[Observation]) -> (str, str):
     columns = []
     for f in fields(obs_class):
         type_str = typing_to_clickhouse(f.type)
-        columns.append(f"     `{f.name}` {type_str}")
+        columns.append(f"     {f.name} {type_str}")
 
     columns_str = ",\n".join(columns)
 
@@ -75,13 +75,13 @@ def create_query_for_observation(obs_class: Type[Observation]) -> str:
     ENGINE = ReplacingMergeTree
     ORDER BY (timestamp, observation_id, measurement_uid)
     SETTINGS index_granularity = 8192;
-    """
+    """, obs_class.__table_name__
 
-def create_query_for_verdict() -> str:
+def create_query_for_verdict() -> (str, str):
     columns = []
     for f in fields(Verdict):
         type_str = typing_to_clickhouse(f.type)
-        columns.append(f"     `{f.name}` {type_str}")
+        columns.append(f"     {f.name} {type_str}")
 
     columns_str = ",\n".join(columns)
 
@@ -92,16 +92,22 @@ def create_query_for_verdict() -> str:
     ENGINE = ReplacingMergeTree
     ORDER BY (timestamp, verdict_id, measurement_uid)
     SETTINGS index_granularity = 8192;
-    """
+    """, "verdict"
 
 def main():
-    print(create_query_for_observation(DNSObservation))
-    print(create_query_for_observation(TCPObservation))
-    print(create_query_for_observation(TLSObservation))
-    print(create_query_for_observation(HTTPObservation))
-    print(create_query_for_observation(NettestObservation))
-
-    print(create_query_for_verdict())
+    create_queries = [
+            create_query_for_observation(DNSObservation),
+            create_query_for_observation(TCPObservation),
+            create_query_for_observation(TLSObservation),
+            create_query_for_observation(HTTPObservation),
+            create_query_for_observation(NettestObservation),
+            create_query_for_verdict(),
+    ]
+    for query, table_name in create_queries:
+        print(f"clickhouse-client -q 'DROP TABLE {table_name}';")
+        print("cat <<EOF | clickhouse-client -nm")
+        print(query)
+        print("EOF")
 
 if __name__ == "__main__":
     main()

--- a/oonidata/db/create_tables.py
+++ b/oonidata/db/create_tables.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Optional, Tuple, List, Any, Type
 from dataclasses import fields
 from oonidata.observations import (
+    NettestObservation,
     Observation,
     DNSObservation,
     TCPObservation,
@@ -53,6 +54,9 @@ def typing_to_clickhouse(t: Any) -> str:
     if t == Outcome:
         return "String"
 
+    if t == dict[str, str]:
+        return "Map(String, String)"
+
     raise Exception(f"Unhandled type {t}")
 
 
@@ -95,6 +99,7 @@ def main():
     print(create_query_for_observation(TCPObservation))
     print(create_query_for_observation(TLSObservation))
     print(create_query_for_observation(HTTPObservation))
+    print(create_query_for_observation(NettestObservation))
 
     print(create_query_for_verdict())
 

--- a/oonidata/observations.py
+++ b/oonidata/observations.py
@@ -244,12 +244,16 @@ class HTTPObservation(Observation):
         )
 
         try:
-            prev_request = requests_list[idx + 1] # type: ignore
+            # We add type: ignore in here, because requests_lists is an optional
+            # field and the fact it might not be defined is handled by the
+            # except block below, yet pylint is not able to figure that out.
+            # TODO: maybe refactor this handle it better by checking if these are defined
+            prev_request = requests_list[idx + 1]  # type: ignore
             prev_location = get_first_http_header(
-                "location", prev_request.response.headers_list_bytes or [] # type: ignore
+                "location", prev_request.response.headers_list_bytes or []  # type: ignore
             ).decode("utf-8")
             if prev_location == hrro.request_url:
-                hrro.request_redirect_from = prev_request.request.url # type: ignore
+                hrro.request_redirect_from = prev_request.request.url  # type: ignore
         except (IndexError, UnicodeDecodeError, AttributeError):
             pass
         return hrro
@@ -332,6 +336,9 @@ class DNSObservation(Observation):
             dnso.answer = answer.hostname
 
         if answer.ipv4 or answer.ipv6:
+            # This is guaranteed to be the correct type since we set it's value
+            # based on answer.ipv4 or answer.ipv6 being set in the previous
+            # blocks
             answer_meta = netinfodb.lookup_ip(dnso.timestamp, dnso.answer)  # type: ignore
             if answer_meta:
                 dnso.answer_asn = answer_meta.as_info.asn
@@ -339,7 +346,7 @@ class DNSObservation(Observation):
                 dnso.answer_as_org_name = answer_meta.as_info.as_org_name
                 dnso.answer_cc = answer_meta.cc
 
-        matched_fingerprint = fingerprintdb.match_dns(dnso.answer) # type: ignore
+        matched_fingerprint = fingerprintdb.match_dns(dnso.answer)
         if matched_fingerprint:
             dnso.fingerprint_id = matched_fingerprint.name
             if matched_fingerprint.expected_countries:

--- a/oonidata/observations.py
+++ b/oonidata/observations.py
@@ -24,7 +24,7 @@ from oonidata.datautils import (
     get_html_title,
     is_ipv4_bogon,
     is_ipv6_bogon,
-    get_certificate_meta,
+    get_certificate_meta
 )
 from oonidata.fingerprints.matcher import FingerprintDB
 from oonidata.netinfo import NetinfoDB
@@ -59,6 +59,7 @@ class Observation(abc.ABC):
 
     software_name: str
     software_version: str
+    test_name: str
     network_type: str
     platform: str
     origin: str
@@ -94,9 +95,10 @@ def make_base_observation_meta(msmt: BaseMeasurement, netinfodb: NetinfoDB) -> d
         session_id=msmt.report_id,
         software_name=msmt.software_name,
         software_version=msmt.software_version,
-        network_type=msmt.annotations.network_type,
-        platform=msmt.annotations.platform,
-        origin=msmt.annotations.origin,
+        test_name=msmt.test_name,
+        network_type=msmt.annotations.get("network_type", "unknown"),
+        platform=msmt.annotations.get("platform", "unknown"),
+        origin=msmt.annotations.get("origin", "unknown"),
         target="",
         resolver_ip=resolver_ip if resolver_ip else "",
         resolver_cc=resolver_as_info.cc if resolver_as_info else "",
@@ -114,6 +116,25 @@ def make_timestamp(msmt: BaseMeasurement, t: Optional[float] = None):
         timestamp += timedelta(seconds=t)
     return timestamp
 
+
+@dataclass
+class NettestObservation(Observation):
+    __table_name__ = "obs_nettest"
+
+    test_runtime: float
+    annotations: dict[str, str]
+
+    @staticmethod
+    def from_measurement(
+        msmt: BaseMeasurement,
+        netinfodb: NetinfoDB,
+    ) -> "NettestObservation":
+        return NettestObservation(
+            test_runtime=msmt.test_runtime,
+            annotations=msmt.annotations,
+            **make_base_observation_meta(msmt, netinfodb),
+        )
+ 
 
 @dataclass
 class HTTPObservation(Observation):

--- a/oonidata/observations.py
+++ b/oonidata/observations.py
@@ -259,6 +259,8 @@ class DNSObservation(Observation):
 
     query_type: str
     failure: Failure
+    engine: Optional[str]
+    engine_resolver_address: Optional[str]
 
     answer_type: Optional[str] = None
     answer: Optional[str] = None
@@ -284,6 +286,8 @@ class DNSObservation(Observation):
     ) -> "DNSObservation":
         dnso = DNSObservation(
             observation_id=f"{msmt.measurement_uid}{idx}",
+            engine=query.engine,
+            engine_resolver_address=query.resolver_address,
             query_type=query.query_type,
             domain_name=query.hostname,
             failure=normalize_failure(query.failure),

--- a/oonidata/observations.py
+++ b/oonidata/observations.py
@@ -130,6 +130,8 @@ class NettestObservation(Observation):
         netinfodb: NetinfoDB,
     ) -> "NettestObservation":
         return NettestObservation(
+            observation_id=f"{msmt.measurement_uid}_nettest",
+            timestamp=make_timestamp(msmt),
             test_runtime=msmt.test_runtime,
             annotations=msmt.annotations,
             **make_base_observation_meta(msmt, netinfodb),
@@ -187,7 +189,7 @@ class HTTPObservation(Observation):
 
         parsed_url = urlparse(http_transaction.request.url)
         hrro = HTTPObservation(
-            observation_id=f"{msmt.measurement_uid}{idx}",
+            observation_id=f"{msmt.measurement_uid}_http_{idx}",
             request_url=http_transaction.request.url,
             domain_name=parsed_url.hostname or "",
             request_is_encrypted=parsed_url.scheme == "https",
@@ -306,7 +308,7 @@ class DNSObservation(Observation):
         netinfodb: NetinfoDB,
     ) -> "DNSObservation":
         dnso = DNSObservation(
-            observation_id=f"{msmt.measurement_uid}{idx}",
+            observation_id=f"{msmt.measurement_uid}_dns_{idx}",
             engine=query.engine,
             engine_resolver_address=query.resolver_address,
             query_type=query.query_type,
@@ -396,7 +398,7 @@ class TCPObservation(Observation):
         netinfodb: NetinfoDB,
     ) -> "TCPObservation":
         tcpo = TCPObservation(
-            observation_id=f"{msmt.measurement_uid}{idx}",
+            observation_id=f"{msmt.measurement_uid}_tcp_{idx}",
             timestamp=make_timestamp(msmt, res.t),
             ip=res.ip,
             port=res.port,
@@ -512,7 +514,7 @@ class TLSObservation(Observation):
         netinfodb: NetinfoDB,
     ) -> "TLSObservation":
         tlso = TLSObservation(
-            observation_id=f"{msmt.measurement_uid}{idx}",
+            observation_id=f"{msmt.measurement_uid}_tls_{idx}",
             timestamp=make_timestamp(msmt, tls_h.t),
             server_name=tls_h.server_name if tls_h.server_name else "",
             domain_name=tls_h.server_name if tls_h.server_name else "",

--- a/oonidata/processing.py
+++ b/oonidata/processing.py
@@ -406,6 +406,7 @@ def process_day(
     country_codes=[],
     start_at_idx=0,
     skip_verdicts=False,
+    fast_fail=False,
 ):
 
     with tqdm(unit="B", unit_scale=True) as pbar:
@@ -436,7 +437,8 @@ def process_day(
                     out_file.write(raw_msmt.decode("utf-8"))
                     out_file.write("\n")
                 log.error(f"Wrote bad msmt to: ./bad_msmts.jsonl")
-                raise exc
+                if fast_fail:
+                    raise exc
 
     if not skip_verdicts:
         write_verdicts_to_db(
@@ -495,6 +497,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--only-verdicts", action="store_true")
     parser.add_argument("--skip-verdicts", action="store_true")
+    parser.add_argument("--fast-fail", action="store_true")
     args = parser.parse_args()
 
     fingerprintdb = FingerprintDB()
@@ -547,4 +550,5 @@ if __name__ == "__main__":
         country_codes=country_codes,
         start_at_idx=args.start_at_idx,
         skip_verdicts=skip_verdicts,
+        fast_fail=args.fast_fail,
     )

--- a/oonidata/processing.py
+++ b/oonidata/processing.py
@@ -436,7 +436,9 @@ def process_day(
                 with open("bad_msmts.jsonl", "a+") as out_file:
                     out_file.write(raw_msmt.decode("utf-8"))
                     out_file.write("\n")
-                log.error(f"Wrote bad msmt to: ./bad_msmts.jsonl")
+                with open("bad_msmts_fail_log.txt", "a+") as out_file:
+                    out_file.write(traceback.format_exc())
+                    out_file.write("ENDTB----\n")
                 if fast_fail:
                     raise exc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,6 @@ def fingerprintdb():
 @pytest.fixture
 def netinfodb():
     return NetinfoDB(
-        datadir=FIXTURE_PATH / "geoip",
-        as_org_map_path=FIXTURE_PATH / "all_as_org_map.json"
+        datadir=FIXTURE_PATH / "historical-geoip" / "country-asn-databases",
+        as_org_map_path=FIXTURE_PATH / "historical-geoip" / "as-orgs" / "all_as_org_map.json"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,12 @@
+import os
+from pathlib import Path
+
 import pytest
 
 from oonidata.fingerprints.matcher import FingerprintDB
 from oonidata.netinfo import NetinfoDB
+
+FIXTURE_PATH = Path(os.path.dirname(os.path.realpath(__file__))) / "data"
 
 @pytest.fixture
 def fingerprintdb():
@@ -9,4 +14,7 @@ def fingerprintdb():
 
 @pytest.fixture
 def netinfodb():
-    return NetinfoDB()
+    return NetinfoDB(
+        datadir=FIXTURE_PATH / "geoip",
+        as_org_map_path=FIXTURE_PATH / "all_as_org_map.json"
+    )


### PR DESCRIPTION
As part of this PR I add support for generating additional observations and enriching existing ones.

Specifically:

* Add a new nettest observation table, which is very close to the existing fastpath table
* Fully parse the annotations keys and store them in a map type column
* Update tests to make use of historical-geoip (note this requires access to the private repo to run the tests)
* Add support for specifying the country you care to reprocess (this is helpful for doing country reports)