### PR TITLE
Body archiver

### DIFF
--- a/oonidata/cli/command.py
+++ b/oonidata/cli/command.py
@@ -303,14 +303,23 @@ def mkgt(
 @start_day_option
 @end_day_option
 @click.option("--clickhouse", type=str)
+@click.option("--data-dir", type=Path, required=True)
 @click.option("--archives-dir", type=Path, required=True)
+@click.option(
+    "--parallelism",
+    type=int,
+    default=multiprocessing.cpu_count() + 2,
+    help="number of processes to use. Only works when writing to a database",
+)
 def mkbodies(
     probe_cc: List[str],
     test_name: List[str],
     start_day: date,
     end_day: date,
     clickhouse: str,
+    data_dir: Path,
     archives_dir: Path,
+    parallelism: int,
 ):
     """
     Make response body archives
@@ -320,8 +329,10 @@ def mkbodies(
         test_name=test_name,
         start_day=start_day,
         end_day=end_day,
+        data_dir=data_dir,
         archives_dir=archives_dir,
         clickhouse=clickhouse,
+        parallelism=parallelism,
     )
 
 

--- a/oonidata/cli/command.py
+++ b/oonidata/cli/command.py
@@ -1,7 +1,6 @@
 import logging
 import multiprocessing
 from pathlib import Path
-import sqlite3
 import sys
 from typing import List, Optional
 from datetime import date, timedelta, datetime
@@ -21,6 +20,7 @@ from oonidata.workers import (
     start_fingerprint_hunter,
     start_observation_maker,
     start_ground_truth_builder,
+    start_response_archiver,
 )
 
 
@@ -129,7 +129,6 @@ def sync(
     required=True,
     help="data directory to store fingerprint and geoip databases",
 )
-@click.option("--archives-dir", type=Path)
 @click.option(
     "--parallelism",
     type=int,
@@ -159,7 +158,6 @@ def mkobs(
     csv_dir: Optional[Path],
     clickhouse: Optional[str],
     data_dir: Path,
-    archives_dir: Optional[Path],
     parallelism: int,
     fast_fail: bool,
     create_tables: bool,
@@ -187,10 +185,6 @@ def mkobs(
             for query, table_name in create_queries:
                 if drop_tables:
                     db.execute(f"DROP TABLE IF EXISTS {table_name};")
-                    if archives_dir:
-                        conn = sqlite3.connect(archives_dir / "graveyard.sqlite3")
-                        conn.execute("DROP TABLE IF EXISTS oonibodies_archive")
-                        conn.commit()
                 db.execute(query)
 
     NetinfoDB(datadir=data_dir, download=True)
@@ -203,7 +197,6 @@ def mkobs(
         csv_dir=csv_dir,
         clickhouse=clickhouse,
         data_dir=data_dir,
-        archives_dir=archives_dir,
         parallelism=parallelism,
         fast_fail=fast_fail,
     )
@@ -301,6 +294,34 @@ def mkgt(
         clickhouse=clickhouse,
         data_dir=data_dir,
         parallelism=parallelism,
+    )
+
+
+@cli.command()
+@probe_cc_option
+@test_name_option
+@start_day_option
+@end_day_option
+@click.option("--clickhouse", type=str)
+@click.option("--archives-dir", type=Path, required=True)
+def mkbodies(
+    probe_cc: List[str],
+    test_name: List[str],
+    start_day: date,
+    end_day: date,
+    clickhouse: str,
+    archives_dir: Path,
+):
+    """
+    Make response body archives
+    """
+    start_response_archiver(
+        probe_cc=probe_cc,
+        test_name=test_name,
+        start_day=start_day,
+        end_day=end_day,
+        archives_dir=archives_dir,
+        clickhouse=clickhouse,
     )
 
 

--- a/oonidata/workers/__init__.py
+++ b/oonidata/workers/__init__.py
@@ -2,3 +2,4 @@ from .experiment_results import start_experiment_result_maker
 from .fingerprint_hunter import start_fingerprint_hunter
 from .observations import start_observation_maker
 from .ground_truths import start_ground_truth_builder
+from .response_archiver import start_response_archiver

--- a/oonidata/workers/response_archiver.py
+++ b/oonidata/workers/response_archiver.py
@@ -1,5 +1,4 @@
 from datetime import date, timedelta
-import gzip
 import io
 import queue
 import time
@@ -12,18 +11,19 @@ import multiprocessing as mp
 from multiprocessing.synchronize import Event as EventClass
 from threading import Lock
 from base64 import b32decode
-import traceback
 
 from typing import (
     List,
     Optional,
     Tuple,
 )
+import orjson
 
 from warcio.warcwriter import WARCWriter
 from warcio.statusandheaders import StatusAndHeaders
 from oonidata.analysis.datasources import load_measurement
 from oonidata.dataclient import date_interval, iter_measurements
+from oonidata.fingerprintdb import FingerprintDB, Fingerprint
 from oonidata.models.nettests.web_connectivity import WebConnectivity
 
 log = logging.getLogger("oonidata.processing")
@@ -81,11 +81,9 @@ class ResponseArchiver:
         status_code: int,
         request_url: str,
         response_headers: List[Tuple[str, bytes]],
-        response_body: Optional[bytes],
+        response_body: bytes,
+        matched_fingerprints: List[Fingerprint],
     ):
-        if not response_body:
-            return
-
         response_body_sha1 = hashlib.sha1(response_body).hexdigest()
 
         if self.is_already_archived(response_body_sha1):
@@ -127,9 +125,25 @@ class ResponseArchiver:
 
         self._warc_writer.write_record(record)
         self.record_idx += 1
+
+        response_fingerprints = []
+        is_fingerprint_false_positive = 0
+        for fp in matched_fingerprints:
+            if fp.scope == "fp":
+                is_fingerprint_false_positive = 1
+            response_fingerprints.append(fp.name)
+
         self.db_conn.execute(
-            "INSERT INTO oonibodies_archive (response_body_sha1, archive_filename, record_idx) VALUES (?, ?, ?)",
-            (response_body_sha1, self.archive_path.name, self.record_idx),
+            """INSERT INTO oonibodies_archive (response_body_sha1, archive_filename, record_idx, is_fingerprint_false_positive, response_fingerprints) 
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                response_body_sha1,
+                self.archive_path.name,
+                self.record_idx,
+                is_fingerprint_false_positive,
+                orjson.dumps(response_fingerprints),
+            ),
         )
         self.db_conn.commit()
 
@@ -168,20 +182,20 @@ class ResponseArchiver:
         self._fh = None
 
 
-def start_response_archiver(
-    probe_cc: List[str],
-    test_name: List[str],
-    start_day: date,
-    end_day: date,
-    clickhouse: Optional[str],
-    archives_dir: pathlib.Path,
-    log_level: int = logging.INFO,
-):
+def response_archiver_worker(day_queue, probe_cc, test_name, archives_dir, data_dir):
     def progress_callback(p):
         print(p)
 
-    response_archiver = ResponseArchiver(dst_dir=archives_dir)
-    for day in date_interval(start_day, end_day):
+    fingerprintdb = FingerprintDB(datadir=data_dir)
+
+    process_id = mp.current_process()._identity[0]
+    machine_id = f"oonidata{process_id}"
+    response_archiver = ResponseArchiver(dst_dir=archives_dir, machine_id=machine_id)
+    while True:
+        try:
+            day = day_queue.get(block=True, timeout=0.1)
+        except queue.Empty:
+            continue
         log.info(f"Archiving bodies for {day}")
         for idx, msmt_dict in enumerate(
             iter_measurements(
@@ -204,15 +218,27 @@ def start_response_archiver(
                             continue
                         request_url = http_transaction.request.url
                         status_code = http_transaction.response.code or 0
+
                         response_headers = (
                             http_transaction.response.headers_list_bytes or []
                         )
+                        # XXX: currently the fingerprint matching only supports str. Maybe we should extend it to work on bytes.
+                        response_headers_str = (
+                            http_transaction.response.headers_list_str or []
+                        )
                         response_body = http_transaction.response.body_bytes
+                        if not response_body:
+                            continue
+
+                        matched_fingerprints = fingerprintdb.match_http(
+                            response_body=response_body, headers=response_headers_str
+                        )
                         response_archiver.archive_http_transaction(
                             status_code=status_code,
                             request_url=request_url,
                             response_headers=response_headers,
                             response_body=response_body,
+                            matched_fingerprints=matched_fingerprints,
                         )
             except Exception:
                 msmt_str = ""
@@ -221,3 +247,33 @@ def start_response_archiver(
                     if msmt.input:
                         msmt_str += f"?input={msmt.input}"
                 log.error(f"failed at idx: {idx} ({msmt_str})", exc_info=True)
+
+
+def start_response_archiver(
+    probe_cc: List[str],
+    test_name: List[str],
+    start_day: date,
+    end_day: date,
+    clickhouse: Optional[str],
+    archives_dir: pathlib.Path,
+    data_dir: pathlib.Path,
+    parallelism: int,
+    log_level: int = logging.INFO,
+):
+    day_queue = mp.Queue()
+
+    pool = mp.Pool(
+        processes=parallelism,
+        initializer=response_archiver_worker,
+        initargs=(day_queue, probe_cc, test_name, archives_dir, data_dir),
+    )
+    for day in date_interval(start_day, end_day):
+        day_queue.put(day)
+
+    for _ in range(parallelism):
+        day_queue.put(None)
+
+    pool.close()
+
+    log.info("waiting for the worker processes to finish")
+    pool.join()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -92,6 +92,7 @@ def test_archive_http_transaction(measurements, tmpdir):
                 status_code=status_code,
                 response_headers=response_headers,
                 response_body=response_body,
+                matched_fingerprints=[]
             )
 
     warc_files = list(dst_dir.glob("*.warc.gz"))
@@ -129,6 +130,7 @@ def test_fingerprint_hunter(fingerprintdb, measurements, tmpdir):
                 status_code=status_code,
                 response_headers=response_headers,
                 response_body=response_body,
+                matched_fingerprints=[]
             )
 
     archive_path = list(archives_dir.glob("*.warc.gz"))[0]


### PR DESCRIPTION
This adds support for archiving bodies as part of a separate command.

It currently write to an on-disk SQLite3 database. In the future we should consider writing to a clickhouse table directly so that we able to parallelise this part of the workflow.