### PR TITLE
Add support for caching netinfodb

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,7 @@ def fingerprintdb(datadir):
 
 @pytest.fixture
 def netinfodb():
-    return NetinfoDB(
-        datadir=DATA_DIR,
-        download=True,
-    )
+    return NetinfoDB(datadir=DATA_DIR, download=True, max_age_seconds=60 * 60 * 24)
 
 
 @pytest.fixture


### PR DESCRIPTION
This implements #52 

The runtime of the `test_transforms.py` goes down from `9 passed in 16.85s` to `9 passed in 3.53s`