### PR TITLE
Fix bug related to hourly processing

### DIFF
--- a/oonipipeline/src/oonipipeline/db/maintenance.py
+++ b/oonipipeline/src/oonipipeline/db/maintenance.py
@@ -166,15 +166,16 @@ def list_duplicates_in_buckets(
             f"""
         SELECT 
         countIf(uid_cnt > 1) as duplicate_uids,
-        bucket_date
+        short_bucket_date
         FROM (
+            WITH concat(substring(bucket_date, 1, 4), '-', substring(bucket_date, 6, 2), '-', substring(bucket_date, 9, 2)) as short_bucket_date
             SELECT
             CONCAT(measurement_uid, '-', toString(observation_idx)) as uid,
             COUNT() as uid_cnt,
-            bucket_date
+            short_bucket_date
             FROM {target_table}
-            WHERE bucket_date IN %(bucket_date)s
-            GROUP BY bucket_date, uid
+            WHERE short_bucket_date IN %(bucket_date)s
+            GROUP BY short_bucket_date, uid
         ) GROUP BY bucket_date
         """,
             params={"bucket_date": bucket_dates},


### PR DESCRIPTION
Since the switch to hourly processing the bucket_dates include the hour timestamp too, this leads to inconsistencies in how the bucket_dates appear in the tables

With this fix we normalize them to always be daily when calculating duplicate measurement_uid, observation_id tuples