### PR TITLE
Replace [scrubbed] IP with scrubbed

### DIFF
--- a/oonipipeline/tests/_fixtures.py
+++ b/oonipipeline/tests/_fixtures.py
@@ -44,6 +44,8 @@ SAMPLE_MEASUREMENTS = [
     "20250319232753.365760_TR_whatsapp_b813f5e363550580",  # TLS HS time bugs
     "20250310005913.071112_TR_signal_e00d1c8955b29d01",  # TLS HS time bugs
     "20250310011757.066396_TR_telegram_7a6b42661eb78d6f",  # TLS HS time bugs
+    "20250125135854.612046_AU_webconnectivity_45560dd5efe1035c",  # Scrubbed IP in DNS answer
+    "20250201172431.190360_CZ_signal_ef68029a5fff6e29",  # Scrubbed IP address in test_keys
 ]
 
 SAMPLE_POSTCANS = ["2024030100_AM_webconnectivity.n1.0.tar.gz"]

--- a/oonipipeline/tests/test_transforms.py
+++ b/oonipipeline/tests/test_transforms.py
@@ -477,3 +477,34 @@ def test_tls_handshake_time(netinfodb, measurements):
         ),
         Telegram,
     )
+
+
+def test_scrubbed_ip(netinfodb, measurements):
+    msmt = load_measurement(
+        msmt_path=measurements[
+            "20250125135854.612046_AU_webconnectivity_45560dd5efe1035c"
+        ]
+    )
+    assert isinstance(msmt, WebConnectivity)
+
+    obs_tup = measurement_to_observations(
+        msmt=msmt, netinfodb=netinfodb, bucket_date="2022-10-13"
+    )
+    assert len(obs_tup) == 2
+    web_obs = obs_tup[0]
+    ctrl_obs = obs_tup[1]
+    assert len(web_obs) == 4
+    assert len(ctrl_obs) == 5
+
+    msmt = load_measurement(
+        msmt_path=measurements["20250201172431.190360_CZ_signal_ef68029a5fff6e29"]
+    )
+    assert isinstance(msmt, Signal)
+
+    obs_tup = measurement_to_observations(
+        msmt=msmt, netinfodb=netinfodb, bucket_date="2022-10-13"
+    )
+    assert len(obs_tup) == 1
+    web_obs = obs_tup[0]
+    assert len(web_obs) == 31
+    assert len(ctrl_obs) == 5


### PR DESCRIPTION
Handle all cases in which the the probe_ip has been scrubbed from measurements and replace its value inside of the relevant tables with the string "scrubbed"

Fixes: https://github.com/ooni/data/issues/130