### PR TITLE
debug: test analysis for negative tls handshakes

### DIFF
--- a/oonipipeline/tests/_fixtures.py
+++ b/oonipipeline/tests/_fixtures.py
@@ -44,6 +44,10 @@ SAMPLE_MEASUREMENTS = [
     "20250319232753.365760_TR_whatsapp_b813f5e363550580",  # TLS HS time bugs
     "20250310005913.071112_TR_signal_e00d1c8955b29d01",  # TLS HS time bugs
     "20250310011757.066396_TR_telegram_7a6b42661eb78d6f",  # TLS HS time bugs
+    "20250310000526.721105_TR_telegram_3e9ee8a20e2dd563", # TLS HS time bugs
+    "20250329234402.651678_TR_signal_c8acd8353b0f2fdd", # TLS HS time bugs
+    "20250310065804.666091_TR_whatsapp_be475c4eec2785ca", # TLS HS time bugs,
+    "20250310070202.610114_TR_whatsapp_bc24253db36a37d6", # TLS HS time bugs
     "20250125135854.612046_AU_webconnectivity_45560dd5efe1035c",  # Scrubbed IP in DNS answer
     "20250201172431.190360_CZ_signal_ef68029a5fff6e29",  # Scrubbed IP address in test_keys
 ]

--- a/oonipipeline/tests/test_transforms.py
+++ b/oonipipeline/tests/test_transforms.py
@@ -467,13 +467,31 @@ def test_tls_handshake_time(netinfodb, measurements):
     )
     check_hs_time_consistency(
         load_measurement(
+            msmt_path=measurements["20250310070202.610114_TR_whatsapp_bc24253db36a37d6"]
+        ),
+        Whatsapp,
+    )
+    check_hs_time_consistency(
+        load_measurement(
             msmt_path=measurements["20250310005913.071112_TR_signal_e00d1c8955b29d01"]
         ),
         Signal,
     )
     check_hs_time_consistency(
         load_measurement(
+            msmt_path=measurements["20250329234402.651678_TR_signal_c8acd8353b0f2fdd"]
+        ),
+        Signal,
+    )
+    check_hs_time_consistency(
+        load_measurement(
             msmt_path=measurements["20250310011757.066396_TR_telegram_7a6b42661eb78d6f"]
+        ),
+        Telegram,
+    )
+    check_hs_time_consistency(
+        load_measurement(
+            msmt_path=measurements["20250310000526.721105_TR_telegram_3e9ee8a20e2dd563"]
         ),
         Telegram,
     )


### PR DESCRIPTION
This diff adds measurement uids which have a negative tls handshake after reprocessing of data in #125 