### PR TITLE
Event detector slack integration

### DIFF
--- a/dags/pipeline.py
+++ b/dags/pipeline.py
@@ -63,7 +63,12 @@ def run_make_analysis(
 
 
 def run_make_event_detector(
-    clickhouse_url: str, probe_cc: List[str], timestamp: str = "", ts: str = "", slack_webhook : str | None = None
+    clickhouse_url: str,
+    probe_cc: List[str],
+    timestamp: str = "",
+    ts: str = "",
+    slack_webhook: str | None = None,
+    explorer_base_url: str = "https://explorer.ooni.org/",
 ):
     from oonipipeline.tasks.detector import MakeDetectorParams, make_detector
 
@@ -71,8 +76,11 @@ def run_make_event_detector(
         timestamp = ts[:13]
 
     params = MakeDetectorParams(
-        clickhouse_url=clickhouse_url, probe_cc=probe_cc, timestamp=timestamp,
-        slack_webhook=slack_webhook
+        clickhouse_url=clickhouse_url,
+        probe_cc=probe_cc,
+        timestamp=timestamp,
+        slack_webhook=slack_webhook,
+        explorer_base_url=explorer_base_url,
     )
 
     make_detector(params)
@@ -231,6 +239,9 @@ with DAG(
             "probe_cc": dag_full.params["probe_cc"],
             "clickhouse_url": Variable.get("clickhouse_url", default_var=""),
             "slack_webhook": Variable.get("slack_webhook", default_var=None),
+            "explorer_base_url": Variable.get(
+                "explorer_base_url", default_var="https://explorer.ooni.org/"
+            ),
             "ts": "{{ts}}",
         },
         requirements=REQUIREMENTS,

--- a/dags/pipeline.py
+++ b/dags/pipeline.py
@@ -63,7 +63,7 @@ def run_make_analysis(
 
 
 def run_make_event_detector(
-    clickhouse_url: str, probe_cc: List[str], timestamp: str = "", ts: str = ""
+    clickhouse_url: str, probe_cc: List[str], timestamp: str = "", ts: str = "", slack_webhook : str | None = None
 ):
     from oonipipeline.tasks.detector import MakeDetectorParams, make_detector
 
@@ -71,7 +71,8 @@ def run_make_event_detector(
         timestamp = ts[:13]
 
     params = MakeDetectorParams(
-        clickhouse_url=clickhouse_url, probe_cc=probe_cc, timestamp=timestamp
+        clickhouse_url=clickhouse_url, probe_cc=probe_cc, timestamp=timestamp,
+        slack_webhook=slack_webhook
     )
 
     make_detector(params)
@@ -229,6 +230,7 @@ with DAG(
         op_kwargs={
             "probe_cc": dag_full.params["probe_cc"],
             "clickhouse_url": Variable.get("clickhouse_url", default_var=""),
+            "slack_webhook": Variable.get("slack_webhook", default_var=None),
             "ts": "{{ts}}",
         },
         requirements=REQUIREMENTS,

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from itertools import groupby as itertools_groupby
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+from urllib.parse import urlencode
 import requests
 
 from clickhouse_driver import Client as ClickhouseClient
@@ -716,7 +717,6 @@ def get_explorer_url(
     def to_s(dt: datetime):
         return datetime.strftime(dt, "%Y-%m-%d")
 
-    from urllib.parse import urlencode
 
     params = {
         "domain": changepoint["domain"],

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -672,11 +672,11 @@ def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_w
     }
 
     messages = []
-    for (i ,cp) in enumerate(changepoints):
+    for (i,cp) in enumerate(changepoints):
         explorer = get_explorer_url(cp)
         message += (
-            f"• :flag-{cp.probe_cc.lower()}: [{cp.probe_cc}/AS{cp.probe_asn}] "
-            f"*{cp.domain}* {change_dir_str[cp.change_dir]} - `{cp.block_type}` "
+            f"• :flag-{cp['probe_cc'].lower()}: [{cp['probe_cc']}/AS{cp['probe_asn']}] "
+            f"*{cp['domain']}* {change_dir_str[cp['change_dir']]} - `{cp['block_type']}` "
             f"| <{explorer}|explorer>\n"
         )
 
@@ -698,8 +698,8 @@ def send_to_slack(webhook : str, message: str):
     }).raise_for_status()
 
 def get_explorer_url(changepoint: Changepoint, base_url: str = "https://explorer.ooni.org/") -> str:
-    start_time = changepoint.ts - timedelta(days=5)
-    end_time = changepoint.ts + timedelta(days=5)
+    start_time = changepoint['ts'] - timedelta(days=5)
+    end_time = changepoint['ts'] + timedelta(days=5)
 
     def to_s(dt: datetime):
         return datetime.strftime(dt, "%Y-%m-%d")
@@ -707,9 +707,9 @@ def get_explorer_url(changepoint: Changepoint, base_url: str = "https://explorer
     from urllib.parse import urlencode
 
     params = {
-        "domain": changepoint.domain,
-        "probe_cc": changepoint.probe_cc,
-        "probe_asn": changepoint.probe_asn,
+        "domain": changepoint['domain'],
+        "probe_cc": changepoint['probe_cc'],
+        "probe_asn": changepoint['probe_asn'],
         "since": to_s(start_time),
         "until": to_s(end_time),
         "axis_x": "measurement_start_day",

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -535,7 +535,7 @@ def run_detector(
     update_tables(db, updated_cusums, changepoints)
 
     if slack_webhook is not None:
-        notify_slack(db, changepoints, slack_webhook, explorer_base_url)
+        notify_slack( changepoints, slack_webhook, explorer_base_url)
 
     return changepoints, updated_cusums, steps
 
@@ -657,7 +657,6 @@ def plot(steps: List[CusumStep], block_type: str):
     chart.show()
 
 def notify_slack(
-    db: ClickhouseClient,
     changepoints: list[Changepoint],
     slack_webhook: str,
     explorer_base_url: str = "https://explorer.ooni.org/",

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -711,8 +711,8 @@ def send_to_slack(webhook: str, message: str):
 def get_explorer_url(
     changepoint: Changepoint, base_url: str = "https://explorer.ooni.org/"
 ) -> str:
-    start_time = changepoint["ts"] - timedelta(days=5)
-    end_time = changepoint["ts"] + timedelta(days=5)
+    start_time = changepoint["ts"] - timedelta(days=13)
+    end_time = changepoint["ts"] + timedelta(days=2)
 
     def to_s(dt: datetime):
         return datetime.strftime(dt, "%Y-%m-%d")

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -662,7 +662,8 @@ def notify_slack(
     explorer_base_url: str = "https://explorer.ooni.org/",
 ):
     """
-    Notifies that there was a change in blocking state of a relevant target
+    Sends a message to slack with a list of all changepoints that were detected
+    in the last run
     """
 
     if len(changepoints) == 0:
@@ -670,18 +671,22 @@ def notify_slack(
 
     message = "*NEW EVENTS DETECTED*\n\nWe just detected the following blocking events:\n"
 
-    change_dir_str = {
-        -1 : "is unblocked :arrow_down: :large_green_circle:",
-        0 : "0? :thinking_face:",
-        1 : "is blocked :arrow_up: :red_circle:"
-    }
+    def dir_to_str(dir : int) -> str:
+        to_str = {
+            -1 : "is unblocked :arrow_down: :large_green_circle:",
+            1 : "is blocked :arrow_up: :red_circle:"
+        }
+        return to_str.get(
+            dir,
+            f"Unknown direction change value: {dir} :thinking_face:"
+        )
 
     messages = []
     for (i, cp) in enumerate(changepoints):
         explorer = get_explorer_url(cp, explorer_base_url)
         message += (
             f"• :flag-{cp['probe_cc'].lower()}: [{cp['probe_cc']}/AS{cp['probe_asn']}] "
-            f"*{cp['domain']}* {change_dir_str[cp['change_dir']]} - `{cp['block_type']}` "
+            f"*{cp['domain']}* {dir_to_str(cp['change_dir'])} - `{cp['block_type']}` "
             f"| <{explorer}|explorer>\n"
         )
 

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -682,9 +682,7 @@ def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_w
         """
 
     # Send message to slack
-    requests.post(slack_webhook, json = {
-        "text" : message
-    })
+    send_to_slack(slack_webhook, message)
 
 def send_to_slack(webhook : str, message: str):
     requests.post(webhook, json = {

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -685,10 +685,12 @@ def notify_slack(
     messages = []
     for i, cp in enumerate(changepoints):
         explorer = get_explorer_url(cp, explorer_base_url)
+        # Alerts panel not yet deployed to prod, we use the test one for now
+        alerts = get_alert_page_url(cp, "https://explorer.test.ooni.org/")
         message += (
             f"• :flag-{cp['probe_cc'].lower()}: [{cp['probe_cc']}/AS{cp['probe_asn']}] "
             f"*{cp['domain']}* {dir_to_str(cp['change_dir'])} - `{cp['block_type']}` "
-            f"| <{explorer}|explorer>\n"
+            f"| <{explorer}|explorer> | <{alerts}|alerts>\n"
         )
 
         # Send messages in 10 entries batches to avoid max message size limit
@@ -726,4 +728,23 @@ def get_explorer_url(
         "axis_x": "measurement_start_day",
     }
     url = f"{base_url}/chart/mat?{urlencode(params)}"
+    return url
+
+def get_alert_page_url(
+    changepoint: Changepoint, base_url: str = "https://explorer.ooni.org/"
+) -> str:
+    start_time = changepoint["ts"] - timedelta(days=13)
+    end_time = changepoint["ts"] + timedelta(days=2)
+
+    def to_s(dt: datetime):
+        return datetime.strftime(dt, "%Y-%m-%d")
+
+    params = {
+        "domain": changepoint["domain"],
+        "probe_cc": changepoint["probe_cc"],
+        "probe_asn": changepoint["probe_asn"],
+        "since": to_s(start_time),
+        "until": to_s(end_time),
+    }
+    url = f"{base_url}/chart/alerts?{urlencode(params)}"
     return url

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -508,7 +508,8 @@ def run_detector(
     gap_halflife: float = 48.0,
     warmup: bool = False,
     trace: bool = False,
-    slack_webhook: str | None = None
+    slack_webhook: str | None = None,
+    explorer_base_url: str = "https://explorer.ooni.org/"
 ) -> Tuple[List[Changepoint], List[LastCusum], List[CusumStep]]:
     db = ClickhouseClient.from_url(clickhouse_url)
     domains = get_domain_list(db)
@@ -534,7 +535,7 @@ def run_detector(
     update_tables(db, updated_cusums, changepoints)
 
     if slack_webhook is not None:
-        notify_slack(db, changepoints, slack_webhook)
+        notify_slack(db, changepoints, slack_webhook, explorer_base_url)
 
     return changepoints, updated_cusums, steps
 
@@ -655,7 +656,12 @@ def plot(steps: List[CusumStep], block_type: str):
     )
     chart.show()
 
-def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_webhook : str):
+def notify_slack(
+    db: ClickhouseClient,
+    changepoints: list[Changepoint],
+    slack_webhook: str,
+    explorer_base_url: str = "https://explorer.ooni.org/",
+):
     """
     Notifies that there was a change in blocking state of a relevant target
     """
@@ -672,8 +678,8 @@ def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_w
     }
 
     messages = []
-    for (i,cp) in enumerate(changepoints):
-        explorer = get_explorer_url(cp)
+    for (i, cp) in enumerate(changepoints):
+        explorer = get_explorer_url(cp, explorer_base_url)
         message += (
             f"• :flag-{cp['probe_cc'].lower()}: [{cp['probe_cc']}/AS{cp['probe_asn']}] "
             f"*{cp['domain']}* {change_dir_str[cp['change_dir']]} - `{cp['block_type']}` "

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -509,7 +509,7 @@ def run_detector(
     warmup: bool = False,
     trace: bool = False,
     slack_webhook: str | None = None,
-    explorer_base_url: str = "https://explorer.ooni.org/"
+    explorer_base_url: str = "https://explorer.ooni.org/",
 ) -> Tuple[List[Changepoint], List[LastCusum], List[CusumStep]]:
     db = ClickhouseClient.from_url(clickhouse_url)
     domains = get_domain_list(db)
@@ -535,7 +535,7 @@ def run_detector(
     update_tables(db, updated_cusums, changepoints)
 
     if slack_webhook is not None:
-        notify_slack( changepoints, slack_webhook, explorer_base_url)
+        notify_slack(changepoints, slack_webhook, explorer_base_url)
 
     return changepoints, updated_cusums, steps
 
@@ -656,6 +656,7 @@ def plot(steps: List[CusumStep], block_type: str):
     )
     chart.show()
 
+
 def notify_slack(
     changepoints: list[Changepoint],
     slack_webhook: str,
@@ -669,20 +670,19 @@ def notify_slack(
     if len(changepoints) == 0:
         return
 
-    message = "*NEW EVENTS DETECTED*\n\nWe just detected the following blocking events:\n"
+    message = (
+        "*NEW EVENTS DETECTED*\n\nWe just detected the following blocking events:\n"
+    )
 
-    def dir_to_str(dir : int) -> str:
+    def dir_to_str(dir: int) -> str:
         to_str = {
-            -1 : "is unblocked :arrow_down: :large_green_circle:",
-            1 : "is blocked :arrow_up: :red_circle:"
+            -1: "is unblocked :arrow_down: :large_green_circle:",
+            1: "is blocked :arrow_up: :red_circle:",
         }
-        return to_str.get(
-            dir,
-            f"Unknown direction change value: {dir} :thinking_face:"
-        )
+        return to_str.get(dir, f"Unknown direction change value: {dir} :thinking_face:")
 
     messages = []
-    for (i, cp) in enumerate(changepoints):
+    for i, cp in enumerate(changepoints):
         explorer = get_explorer_url(cp, explorer_base_url)
         message += (
             f"• :flag-{cp['probe_cc'].lower()}: [{cp['probe_cc']}/AS{cp['probe_asn']}] "
@@ -691,7 +691,7 @@ def notify_slack(
         )
 
         # Send messages in 10 entries batches to avoid max message size limit
-        if (i+1) % 10 == 0:
+        if (i + 1) % 10 == 0:
             messages.append(message)
             message = ""
 
@@ -702,14 +702,16 @@ def notify_slack(
     for msg in messages:
         send_to_slack(slack_webhook, msg)
 
-def send_to_slack(webhook : str, message: str):
-    requests.post(webhook, json = {
-        "text" : message
-    }).raise_for_status()
 
-def get_explorer_url(changepoint: Changepoint, base_url: str = "https://explorer.ooni.org/") -> str:
-    start_time = changepoint['ts'] - timedelta(days=5)
-    end_time = changepoint['ts'] + timedelta(days=5)
+def send_to_slack(webhook: str, message: str):
+    requests.post(webhook, json={"text": message}).raise_for_status()
+
+
+def get_explorer_url(
+    changepoint: Changepoint, base_url: str = "https://explorer.ooni.org/"
+) -> str:
+    start_time = changepoint["ts"] - timedelta(days=5)
+    end_time = changepoint["ts"] + timedelta(days=5)
 
     def to_s(dt: datetime):
         return datetime.strftime(dt, "%Y-%m-%d")
@@ -717,9 +719,9 @@ def get_explorer_url(changepoint: Changepoint, base_url: str = "https://explorer
     from urllib.parse import urlencode
 
     params = {
-        "domain": changepoint['domain'],
-        "probe_cc": changepoint['probe_cc'],
-        "probe_asn": changepoint['probe_asn'],
+        "domain": changepoint["domain"],
+        "probe_cc": changepoint["probe_cc"],
+        "probe_asn": changepoint["probe_asn"],
         "since": to_s(start_time),
         "until": to_s(end_time),
         "axis_x": "measurement_start_day",

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -717,7 +717,6 @@ def get_explorer_url(
     def to_s(dt: datetime):
         return datetime.strftime(dt, "%Y-%m-%d")
 
-
     params = {
         "domain": changepoint["domain"],
         "probe_cc": changepoint["probe_cc"],

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from itertools import groupby as itertools_groupby
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+import requests
 
 from clickhouse_driver import Client as ClickhouseClient
 
@@ -649,3 +650,33 @@ def plot(steps: List[CusumStep], block_type: str):
         .interactive()
     )
     chart.show()
+
+def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_webhook : str):
+    """
+    Notifies that there was a change in blocking state of a relevant target
+    """
+
+    if len(changepoints) == 0:
+        return
+
+    message = """
+    **NEW EVENTS DETECTED**
+
+    We just detected the following blocking events:
+    """
+
+    change_dir_str = {
+        -1 : "is unblocked :arrow_down: :large_green_circle:",
+        0 : "0? :thinking_face:",
+        1 : "is blocked :arrow_up: :red_circle:"
+    }
+
+    for cp in changepoints:
+        message = message + f"""
+        \t- :flag-{cp.probe_cc.lower()}:[{cp.probe_cc}/AS{cp.probe_asn}] **{cp.domain}** {change_dir_str[cp.change_dir]} - `{cp.block_type}`
+        """
+
+    # Send message to slack
+    requests.post(slack_webhook, json = {
+        "text" : message
+    })

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -508,6 +508,7 @@ def run_detector(
     gap_halflife: float = 48.0,
     warmup: bool = False,
     trace: bool = False,
+    slack_webhook: str | None = None
 ) -> Tuple[List[Changepoint], List[LastCusum], List[CusumStep]]:
     db = ClickhouseClient.from_url(clickhouse_url)
     domains = get_domain_list(db)
@@ -532,7 +533,8 @@ def run_detector(
     )
     update_tables(db, updated_cusums, changepoints)
 
-    notify_slack(db, changepoints)
+    if slack_webhook is not None:
+        notify_slack(db, changepoints, slack_webhook)
 
     return changepoints, updated_cusums, steps
 
@@ -661,11 +663,7 @@ def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_w
     if len(changepoints) == 0:
         return
 
-    message = """
-    *NEW EVENTS DETECTED*
-
-    We just detected the following blocking events:
-    """
+    message = "*NEW EVENTS DETECTED*\n\nWe just detected the following blocking events:\n"
 
     change_dir_str = {
         -1 : "is unblocked :arrow_down: :large_green_circle:",
@@ -673,16 +671,26 @@ def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_w
         1 : "is blocked :arrow_up: :red_circle:"
     }
 
-    # Divide the message in several parts
-
-    for cp in changepoints:
+    messages = []
+    for (i ,cp) in enumerate(changepoints):
         explorer = get_explorer_url(cp)
-        message = message + f"""
-        \t- :flag-{cp.probe_cc.lower()}:[{cp.probe_cc}/AS{cp.probe_asn}] *{cp.domain}* {change_dir_str[cp.change_dir]} - `{cp.block_type}` | <{explorer}|explorer>
-        """
+        message += (
+            f"• :flag-{cp.probe_cc.lower()}: [{cp.probe_cc}/AS{cp.probe_asn}] "
+            f"*{cp.domain}* {change_dir_str[cp.change_dir]} - `{cp.block_type}` "
+            f"| <{explorer}|explorer>\n"
+        )
 
-    # Send message to slack
-    send_to_slack(slack_webhook, message)
+        # Send messages in 10 entries batches to avoid max message size limit
+        if (i+1) % 10 == 0:
+            messages.append(message)
+            message = ""
+
+    if message != "":
+        messages.append(message)
+
+    # Send messages to slack
+    for msg in messages:
+        send_to_slack(slack_webhook, msg)
 
 def send_to_slack(webhook : str, message: str):
     requests.post(webhook, json = {

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -532,6 +532,8 @@ def run_detector(
     )
     update_tables(db, updated_cusums, changepoints)
 
+    notify_slack(db, changepoints)
+
     return changepoints, updated_cusums, steps
 
 
@@ -660,7 +662,7 @@ def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_w
         return
 
     message = """
-    **NEW EVENTS DETECTED**
+    *NEW EVENTS DETECTED*
 
     We just detected the following blocking events:
     """
@@ -671,12 +673,40 @@ def notify_slack(db : ClickhouseClient, changepoints: list[Changepoint], slack_w
         1 : "is blocked :arrow_up: :red_circle:"
     }
 
+    # Divide the message in several parts
+
     for cp in changepoints:
+        explorer = get_explorer_url(cp)
         message = message + f"""
-        \t- :flag-{cp.probe_cc.lower()}:[{cp.probe_cc}/AS{cp.probe_asn}] **{cp.domain}** {change_dir_str[cp.change_dir]} - `{cp.block_type}`
+        \t- :flag-{cp.probe_cc.lower()}:[{cp.probe_cc}/AS{cp.probe_asn}] *{cp.domain}* {change_dir_str[cp.change_dir]} - `{cp.block_type}` | <{explorer}|explorer>
         """
 
     # Send message to slack
     requests.post(slack_webhook, json = {
         "text" : message
     })
+
+def send_to_slack(webhook : str, message: str):
+    requests.post(webhook, json = {
+        "text" : message
+    }).raise_for_status()
+
+def get_explorer_url(changepoint: Changepoint, base_url: str = "https://explorer.ooni.org/") -> str:
+    start_time = changepoint.ts - timedelta(days=5)
+    end_time = changepoint.ts + timedelta(days=5)
+
+    def to_s(dt: datetime):
+        return datetime.strftime(dt, "%Y-%m-%d")
+
+    from urllib.parse import urlencode
+
+    params = {
+        "domain": changepoint.domain,
+        "probe_cc": changepoint.probe_cc,
+        "probe_asn": changepoint.probe_asn,
+        "since": to_s(start_time),
+        "until": to_s(end_time),
+        "axis_x": "measurement_start_day",
+    }
+    url = f"{base_url}/chart/mat?{urlencode(params)}"
+    return url

--- a/oonipipeline/src/oonipipeline/tasks/detector.py
+++ b/oonipipeline/src/oonipipeline/tasks/detector.py
@@ -10,7 +10,8 @@ class MakeDetectorParams:
     clickhouse_url: str
     probe_cc: List[str]
     timestamp: str
-    slack_webhook: str | None
+    slack_webhook: str | None = None
+    explorer_base_url: str = "https://explorer.ooni.org/"
 
 
 def make_detector(params: MakeDetectorParams):
@@ -30,5 +31,6 @@ def make_detector(params: MakeDetectorParams):
         start_time=start_hour,
         end_time=end_hour,
         probe_cc=params.probe_cc,
-        slack_webhook=params.slack_webhook
+        slack_webhook=params.slack_webhook,
+        explorer_base_url=params.explorer_base_url,
     )

--- a/oonipipeline/src/oonipipeline/tasks/detector.py
+++ b/oonipipeline/src/oonipipeline/tasks/detector.py
@@ -10,6 +10,7 @@ class MakeDetectorParams:
     clickhouse_url: str
     probe_cc: List[str]
     timestamp: str
+    slack_webhook: str | None
 
 
 def make_detector(params: MakeDetectorParams):
@@ -29,4 +30,5 @@ def make_detector(params: MakeDetectorParams):
         start_time=start_hour,
         end_time=end_hour,
         probe_cc=params.probe_cc,
+        slack_webhook=params.slack_webhook
     )

--- a/oonipipeline/tests/test_e2e.py
+++ b/oonipipeline/tests/test_e2e.py
@@ -123,7 +123,7 @@ def test_event_detector(datadir, db):
         )
         make_detector(
             MakeDetectorParams(
-                clickhouse_url=db.clickhouse_url, probe_cc=["TG"], timestamp=timestamp
+                clickhouse_url=db.clickhouse_url, probe_cc=["TG"], timestamp=timestamp, slack_webhook=None
             )
         )
     res = db.execute("SELECT COUNT() FROM event_detector_changepoints")


### PR DESCRIPTION
This PR will implement a slack integration to publish the results of the event detector to a dedicated Slack channel. 

It works by composing a message with the list of detected changes after an hourly detector run, and sending a `POST` request into a Slack webhook with this message 

The slack webhook should be specified as an Airflow variable from the Airflow panel

 