### PR TITLE
catch ValueError on changed = "latest"

### DIFF
--- a/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
+++ b/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
@@ -39,7 +39,13 @@ def fetch_data() -> List[dict]:
     for asn, history in j.items():
         asn = int(asn)
         for v in history:
-            changed = datetime.strptime(v[2], "%Y%m%d").date()
+            try:
+                changed = datetime.strptime(v[2], "%Y%m%d").date()
+            except ValueError:
+                if v == "latest":
+                    changed = v
+                else:
+                    raise
             rows.append(
                 {
                     "asn": asn,

--- a/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
+++ b/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
@@ -42,12 +42,7 @@ def fetch_data() -> List[dict]:
             try:
                 changed = datetime.strptime(v[2], "%Y%m%d").date()
             except ValueError:
-                # Accept "latest" for changed
-                # fixes https://github.com/ooni/data/issues/164
-                if v[2] == "latest":
-                    changed = v[2]
-                else:
-                    raise
+                changed = None
             rows.append(
                 {
                     "asn": asn,

--- a/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
+++ b/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
@@ -44,7 +44,7 @@ def fetch_data() -> List[dict]:
             except ValueError:
                 # Accept "latest" for changed
                 # fixes https://github.com/ooni/data/issues/164
-                if v == "latest":
+                if v[2] == "latest":
                     changed = v
                 else:
                     raise

--- a/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
+++ b/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
@@ -42,6 +42,8 @@ def fetch_data() -> List[dict]:
             try:
                 changed = datetime.strptime(v[2], "%Y%m%d").date()
             except ValueError:
+                # Accept "latest" for changed
+                # fixes https://github.com/ooni/data/issues/164
                 if v == "latest":
                     changed = v
                 else:

--- a/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
+++ b/oonipipeline/src/oonipipeline/tasks/updaters/asnmeta_updater.py
@@ -45,7 +45,7 @@ def fetch_data() -> List[dict]:
                 # Accept "latest" for changed
                 # fixes https://github.com/ooni/data/issues/164
                 if v[2] == "latest":
-                    changed = v
+                    changed = v[2]
                 else:
                     raise
             rows.append(


### PR DESCRIPTION
When parsing the all_as_org_map:
https://archive.org/download/ip2country-as/all_as_org_map.json
produced by https://github.com/ooni/historical-geoip/blob/main/build_all_as_org_map.py
the upstream data source has included "latest" for the "changed" field rather than a specific day.

This metadata probably does not affect the behavior of clients, but this has not been verified.

This changes the updater to accept "latest" as a value.