### PR TITLE
Event detector debugging panel

### DIFF
--- a/oonipipeline/pyproject.toml
+++ b/oonipipeline/pyproject.toml
@@ -40,6 +40,7 @@ analysis = [
   "altair ~= 4.2.0",
   "jupyterlab ~= 4.0.7",
   "bokeh ~= 3.5.2",
+  "streamlit",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/oonipipeline/pyproject.toml
+++ b/oonipipeline/pyproject.toml
@@ -41,6 +41,7 @@ analysis = [
   "jupyterlab ~= 4.0.7",
   "bokeh ~= 3.5.2",
   "streamlit",
+  "pyarrow < 19", # fixes segfault with streamlit
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/oonipipeline/pyproject.toml
+++ b/oonipipeline/pyproject.toml
@@ -80,3 +80,7 @@ test = "pytest {args:tests}"
 test-cov = "pytest --cov=./ --cov-report=xml --cov-report=html --cov-report=term {args:tests}"
 cov-report = ["coverage report"]
 cov = ["test-cov", "cov-report"]
+
+[tool.hatch.envs.analysis]
+template = "default"
+features = ["analysis"]

--- a/oonipipeline/src/oonipipeline/analysis/detector.py
+++ b/oonipipeline/src/oonipipeline/analysis/detector.py
@@ -540,8 +540,47 @@ def run_detector(
 
     return changepoints, updated_cusums, steps
 
+def run_detector_for(
+    clickhouse_url: str,
+    start_time: datetime,
+    end_time: datetime,
+    probe_cc: str,
+    domains: List[str],
+    edd: int = 10,
+    gap_halflife: float = 48.0,
+    warmup: bool = True,
+    trace: bool = True,
+) -> Tuple[List[Changepoint], List[LastCusum], List[CusumStep]]:
+    """
+    Runs the detector for a specific probe_cc, asn, domain, returning the
+    results without saving it to database.
+    """
+    db = ClickhouseClient.from_url(clickhouse_url)
+
+    observations = get_observations(
+        db,
+        start_time=start_time,
+        end_time=end_time,
+        probe_cc=[probe_cc],
+        domains=domains,
+    )
+
+    changepoints, updated_cusums, steps = detect_changepoints(
+        observations=observations,
+        cusum_map={},
+        edd=edd,
+        gap_halflife=gap_halflife,
+        analysis_columns=ANALYSIS_COLS,
+        warmup=warmup,
+        trace=trace,
+    )
+
+    return changepoints, updated_cusums, steps
 
 def plot(steps: List[CusumStep], block_type: str):
+    make_cusums_chart(steps, block_type).show()
+
+def make_cusums_chart(steps: List[CusumStep], block_type: str):
     import altair as alt
     import pandas as pd
 
@@ -655,8 +694,7 @@ def plot(steps: List[CusumStep], block_type: str):
         )
         .interactive()
     )
-    chart.show()
-
+    return chart
 
 def notify_slack(
     changepoints: list[Changepoint],

--- a/oonipipeline/src/oonipipeline/cli/commands.py
+++ b/oonipipeline/src/oonipipeline/cli/commands.py
@@ -1,6 +1,5 @@
 import logging
-from datetime import date, datetime, timedelta, timezone
-from pathlib import Path
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 import click
@@ -28,7 +27,6 @@ from oonipipeline.tasks.observations import (
 from ..__about__ import VERSION
 from ..db.connections import ClickhouseConnection
 from ..db.create_tables import list_all_table_diffs, make_create_queries
-from ..netinfo import NetinfoDB
 from ..settings import config
 
 
@@ -358,3 +356,25 @@ def event_detector(
         click.echo(
             f"Found {len(changepoints)} changepoints and updated {len(updated_cusums)} cusums"
         )
+
+@cli.command()
+@click.option("--port", default=8501, help="Port the web server will listen to")
+def events_panel(port: int):
+    """
+    Starts a streamlit web app with the events detector debugging panel
+    """
+    try:
+        from streamlit.web import bootstrap
+    except ImportError:
+        click.echo("Streamlit not available. Install with oonipipeline[analysis]")
+        return
+
+    import importlib.util
+
+    spec = importlib.util.find_spec("oonipipeline.events_panel.panel")
+    assert spec is not None, "Unable to find events panel module"
+    panel_path = spec.origin  # file path, no execution
+
+    flag_options = {"server.port": port}
+    bootstrap.load_config_options(flag_options=flag_options)
+    bootstrap.run(panel_path, is_hello=False, args=[], flag_options=flag_options)

--- a/oonipipeline/src/oonipipeline/events_panel/panel.py
+++ b/oonipipeline/src/oonipipeline/events_panel/panel.py
@@ -23,6 +23,7 @@ def to_datetime(d: date):
 def run_detector_cached(*args, **kwargs):
     return run_detector_for(*args, **kwargs)
 
+st.set_page_config(layout="wide")
 
 def detector_panel():
     st.write(
@@ -106,14 +107,15 @@ def detector_panel():
         st.warning(f"No cusum steps found for ASN {selected_asn}")
         return
 
-    st.altair_chart(make_cusums_chart(sample(chart_steps, 1000), "dns_isp_blocked"))
+    c1, c2 = st.columns([3,1])
+    c1.altair_chart(make_cusums_chart(sample(chart_steps, 1000), "dns_isp_blocked"))
 
     if asns:
         df = pd.DataFrame({"ASN": list(asns.keys()), "total": list(asns.values())})
         df = df.sort_values("total", ascending=False).reset_index(drop=True)
         df["ASN"] = df["ASN"].astype(str)
 
-        event = st.dataframe(
+        event = c2.dataframe(
             df,
             hide_index=True,
             on_select="rerun",

--- a/oonipipeline/src/oonipipeline/events_panel/panel.py
+++ b/oonipipeline/src/oonipipeline/events_panel/panel.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
 import streamlit as st
 from oonipipeline.analysis.detector import make_cusums_chart, run_detector_for
-from datetime import datetime, timezone, timedelta, date
+from datetime import datetime, timezone, timedelta, date, tzinfo
 import logging
+import pandas as pd
 
 log = logging.getLogger(__name__)
 
@@ -14,44 +15,51 @@ def sample(lst: list, n: int):
     return [lst[int(i * step)] for i in range(n)]
 
 def to_datetime(d: date):
-    datetime.combine(d, datetime.min.time(), timezone.utc)
+    return datetime(year=d.year, month=d.month, day=d.day, hour=0, tzinfo=timezone.utc)
 
-st.write(
+
+def detector_panel():
+    st.write(
+        """
+    # Event Detector
+    Run the event detector over the specified input to get a simulation of results
+    for the given input
+    Results are **not** saved to db
     """
-# Event Detector
-Run the event detector over the specified input to get a simulation of results
-for the given input
-Results are **not** saved to db
-"""
-)
+    )
 
-now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc)
 
-clickhouse_url = st.sidebar.text_input(
-    "**Clickhouse url**", "clickhouse://localhost:9000/ooni"
-)
+    clickhouse_url = st.sidebar.text_input(
+        "**Clickhouse url**", "clickhouse://localhost:9000/ooni"
+    )
 
-with st.form("detector_params"):
-    c1, c2 = st.columns(2)
+    with st.form("detector_params"):
+        c1, c2 = st.columns(2)
 
-    # column 1
-    start_time = c1.date_input("**Start time**", now - timedelta(days=30))
-    probe_cc = c1.text_input("**Country code (two chars)**", "VE")
-    edd = c1.number_input("**Estimated Detection Delay (EDD)**", value=10)
+        # column 1
+        start_time = c1.date_input("**Start time**", now - timedelta(days=30))
+        probe_cc = c1.text_input("**Country code (two chars)**", "VE")
+        edd = c1.number_input("**Estimated Detection Delay (EDD)**", value=10)
 
-    # column2
-    end_time = c2.date_input("**End time**", now)
-    domain = c2.text_input("**domain**", "x.com")
-    gap_halflife = c2.number_input("**Gap half life**", value=48.0)
+        # column2
+        end_time = c2.date_input("**End time**", now)
+        domain = c2.text_input("**domain**", "x.com")
+        gap_halflife = c2.number_input("**Gap half life**", value=48.0)
 
-    warmup = st.checkbox("**Warmup**", True)
-    submitted = st.form_submit_button("Run detector")
+        warmup = st.checkbox("**Warmup**", True)
+        submitted = st.form_submit_button("Run detector")
 
 
+    # Nothing else to draw
+    if not submitted:
+        return
 
+    @st.cache_data(ttl=300)
+    def run_detector_cached(*args, **kwargs):
+        return run_detector_for(*args, **kwargs)
 
-if submitted:
-    changepoints, _, cusum_steps = run_detector_for(
+    changepoints, _, cusum_steps = run_detector_cached(
         clickhouse_url,
         to_datetime(start_time),
         to_datetime(end_time),
@@ -62,15 +70,21 @@ if submitted:
         warmup,
     )
 
+    if len(cusum_steps) == 0:
+        st.warning("The detector ran successfully but **no cusum steps were returned** for the given inputs")
+        return
+
     asns = defaultdict(int)
     for step in cusum_steps:
         asns[step['probe_asn']] += 1
 
-    # st.table(asns)
-
-    st.altair_chart(make_cusums_chart(sample(cusum_steps, 1000), "dns_isp_blocked"))
     c1, c2 = st.columns(2)
     c1.write(f"Changepoints: **{len(changepoints)}**")
     c2.write(f"Cusum steps: **{len(cusum_steps)}**")
 
-    pass
+    st.altair_chart(make_cusums_chart(sample(cusum_steps, 1000), "dns_isp_blocked"))
+
+    if asns:
+        st.table(pd.DataFrame({'ASN': list(asns.keys()), 'total':list(asns.values())}))
+
+detector_panel()

--- a/oonipipeline/src/oonipipeline/events_panel/panel.py
+++ b/oonipipeline/src/oonipipeline/events_panel/panel.py
@@ -1,0 +1,76 @@
+from collections import defaultdict
+import streamlit as st
+from oonipipeline.analysis.detector import make_cusums_chart, run_detector_for
+from datetime import datetime, timezone, timedelta, date
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def sample(lst: list, n: int):
+    if n >= len(lst):
+        return lst
+    step = len(lst) / n
+    return [lst[int(i * step)] for i in range(n)]
+
+def to_datetime(d: date):
+    datetime.combine(d, datetime.min.time(), timezone.utc)
+
+st.write(
+    """
+# Event Detector
+Run the event detector over the specified input to get a simulation of results
+for the given input
+Results are **not** saved to db
+"""
+)
+
+now = datetime.now(timezone.utc)
+
+clickhouse_url = st.sidebar.text_input(
+    "**Clickhouse url**", "clickhouse://localhost:9000/ooni"
+)
+
+with st.form("detector_params"):
+    c1, c2 = st.columns(2)
+
+    # column 1
+    start_time = c1.date_input("**Start time**", now - timedelta(days=30))
+    probe_cc = c1.text_input("**Country code (two chars)**", "VE")
+    edd = c1.number_input("**Estimated Detection Delay (EDD)**", value=10)
+
+    # column2
+    end_time = c2.date_input("**End time**", now)
+    domain = c2.text_input("**domain**", "x.com")
+    gap_halflife = c2.number_input("**Gap half life**", value=48.0)
+
+    warmup = st.checkbox("**Warmup**", True)
+    submitted = st.form_submit_button("Run detector")
+
+
+
+
+if submitted:
+    changepoints, _, cusum_steps = run_detector_for(
+        clickhouse_url,
+        to_datetime(start_time),
+        to_datetime(end_time),
+        probe_cc,
+        [domain],
+        edd,
+        gap_halflife,
+        warmup,
+    )
+
+    asns = defaultdict(int)
+    for step in cusum_steps:
+        asns[step['probe_asn']] += 1
+
+    # st.table(asns)
+
+    st.altair_chart(make_cusums_chart(sample(cusum_steps, 1000), "dns_isp_blocked"))
+    c1, c2 = st.columns(2)
+    c1.write(f"Changepoints: **{len(changepoints)}**")
+    c2.write(f"Cusum steps: **{len(cusum_steps)}**")
+
+    pass

--- a/oonipipeline/src/oonipipeline/events_panel/panel.py
+++ b/oonipipeline/src/oonipipeline/events_panel/panel.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import streamlit as st
 from oonipipeline.analysis.detector import make_cusums_chart, run_detector_for
-from datetime import datetime, timezone, timedelta, date, tzinfo
+from datetime import datetime, timezone, timedelta, date
 import logging
 import pandas as pd
 
@@ -14,8 +14,14 @@ def sample(lst: list, n: int):
     step = len(lst) / n
     return [lst[int(i * step)] for i in range(n)]
 
+
 def to_datetime(d: date):
     return datetime(year=d.year, month=d.month, day=d.day, hour=0, tzinfo=timezone.utc)
+
+
+@st.cache_data(ttl=300)
+def run_detector_cached(*args, **kwargs):
+    return run_detector_for(*args, **kwargs)
 
 
 def detector_panel():
@@ -50,41 +56,76 @@ def detector_panel():
         warmup = st.checkbox("**Warmup**", True)
         submitted = st.form_submit_button("Run detector")
 
+    # Only recompute on submit; store in session_state so results survive
+    # the rerun triggered by clicking a table row.
+    if submitted:
+        changepoints, _, cusum_steps = run_detector_cached(
+            clickhouse_url,
+            to_datetime(start_time),
+            to_datetime(end_time),
+            probe_cc,
+            [domain],
+            edd,
+            gap_halflife,
+            warmup,
+        )
+        st.session_state["changepoints"] = changepoints
+        st.session_state["cusum_steps"] = cusum_steps
+        st.session_state["selected_asn"] = None  # reset selection on new run
 
-    # Nothing else to draw
-    if not submitted:
+    if "cusum_steps" not in st.session_state:
         return
 
-    @st.cache_data(ttl=300)
-    def run_detector_cached(*args, **kwargs):
-        return run_detector_for(*args, **kwargs)
-
-    changepoints, _, cusum_steps = run_detector_cached(
-        clickhouse_url,
-        to_datetime(start_time),
-        to_datetime(end_time),
-        probe_cc,
-        [domain],
-        edd,
-        gap_halflife,
-        warmup,
-    )
+    changepoints = st.session_state["changepoints"]
+    cusum_steps = st.session_state["cusum_steps"]
 
     if len(cusum_steps) == 0:
-        st.warning("The detector ran successfully but **no cusum steps were returned** for the given inputs")
+        st.warning(
+            "The detector ran successfully but **no cusum steps were returned** for the given inputs"
+        )
         return
 
     asns = defaultdict(int)
     for step in cusum_steps:
-        asns[step['probe_asn']] += 1
+        asns[step["probe_asn"]] += 1
 
     c1, c2 = st.columns(2)
     c1.write(f"Changepoints: **{len(changepoints)}**")
     c2.write(f"Cusum steps: **{len(cusum_steps)}**")
 
-    st.altair_chart(make_cusums_chart(sample(cusum_steps, 1000), "dns_isp_blocked"))
+    # Which ASN to filter the chart by: selected row takes priority,
+    # else default to the ASN with the highest count.
+    selected_asn = st.session_state.get("selected_asn") or max(asns, key=asns.get)
+
+    st.write(f"**Filtering chart by ASN: {selected_asn}**")
+    chart_steps = [
+        s for s in cusum_steps if str(s["probe_asn"]) == str(selected_asn)
+    ]
+
+    if len(chart_steps) == 0:
+        st.warning(f"No cusum steps found for ASN {selected_asn}")
+        return
+
+    st.altair_chart(make_cusums_chart(sample(chart_steps, 1000), "dns_isp_blocked"))
 
     if asns:
-        st.table(pd.DataFrame({'ASN': list(asns.keys()), 'total':list(asns.values())}))
+        df = pd.DataFrame({"ASN": list(asns.keys()), "total": list(asns.values())})
+        df = df.sort_values("total", ascending=False).reset_index(drop=True)
+        df["ASN"] = df["ASN"].astype(str)
+
+        event = st.dataframe(
+            df,
+            hide_index=True,
+            on_select="rerun",
+            selection_mode="single-row",
+            key="asn_table",
+        )
+
+        if event.selection.rows:
+            row = df.iloc[event.selection.rows[0]]
+            if st.session_state.get("selected_asn") != row["ASN"]:
+                st.session_state["selected_asn"] = row["ASN"]
+                st.rerun()
+
 
 detector_panel()

--- a/oonipipeline/src/oonipipeline/events_panel/panel.py
+++ b/oonipipeline/src/oonipipeline/events_panel/panel.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import streamlit as st
-from oonipipeline.analysis.detector import make_cusums_chart, run_detector_for
+from oonipipeline.analysis.detector import make_cusums_chart, run_detector_for, ANALYSIS_COLS
 from datetime import datetime, timezone, timedelta, date
 import logging
 import pandas as pd
@@ -58,7 +58,7 @@ def detector_panel():
         submitted = st.form_submit_button("Run detector")
 
     # Only recompute on submit; store in session_state so results survive
-    # the rerun triggered by clicking a table row.
+    # reruns triggered by the selectboxes below.
     if submitted:
         changepoints, _, cusum_steps = run_detector_cached(
             clickhouse_url,
@@ -72,7 +72,6 @@ def detector_panel():
         )
         st.session_state["changepoints"] = changepoints
         st.session_state["cusum_steps"] = cusum_steps
-        st.session_state["selected_asn"] = None  # reset selection on new run
 
     if "cusum_steps" not in st.session_state:
         return
@@ -94,40 +93,26 @@ def detector_panel():
     c1.write(f"Changepoints: **{len(changepoints)}**")
     c2.write(f"Cusum steps: **{len(cusum_steps)}**")
 
-    # Which ASN to filter the chart by: selected row takes priority,
-    # else default to the ASN with the highest count.
-    selected_asn = st.session_state.get("selected_asn") or max(asns, key=asns.get)
+    c1, c2 = st.columns(2)
+    block_type = c1.selectbox("Block type", [c[0] for c in ANALYSIS_COLS])
 
-    st.write(f"**Filtering chart by ASN: {selected_asn}**")
-    chart_steps = [
-        s for s in cusum_steps if str(s["probe_asn"]) == str(selected_asn)
-    ]
+    asn_list = list(asns.keys())
+    asn_list.sort(key=lambda k: asns[k], reverse=True)
+    selected_asn = c2.selectbox("ASN", asn_list, format_func=lambda k: f"{k} ({asns[k]})")
+
+    chart_steps = [s for s in cusum_steps if s["probe_asn"] == selected_asn]
 
     if len(chart_steps) == 0:
         st.warning(f"No cusum steps found for ASN {selected_asn}")
         return
 
-    c1, c2 = st.columns([3,1])
-    c1.altair_chart(make_cusums_chart(sample(chart_steps, 1000), "dns_isp_blocked"))
+    st.altair_chart(make_cusums_chart(sample(chart_steps, 1000), block_type))
 
     if asns:
         df = pd.DataFrame({"ASN": list(asns.keys()), "total": list(asns.values())})
         df = df.sort_values("total", ascending=False).reset_index(drop=True)
         df["ASN"] = df["ASN"].astype(str)
-
-        event = c2.dataframe(
-            df,
-            hide_index=True,
-            on_select="rerun",
-            selection_mode="single-row",
-            key="asn_table",
-        )
-
-        if event.selection.rows:
-            row = df.iloc[event.selection.rows[0]]
-            if st.session_state.get("selected_asn") != row["ASN"]:
-                st.session_state["selected_asn"] = row["ASN"]
-                st.rerun()
+        st.dataframe(df, hide_index=True)
 
 
 detector_panel()

--- a/oonipipeline/src/oonipipeline/events_panel/panel.py
+++ b/oonipipeline/src/oonipipeline/events_panel/panel.py
@@ -7,14 +7,6 @@ import pandas as pd
 
 log = logging.getLogger(__name__)
 
-
-def sample(lst: list, n: int):
-    if n >= len(lst):
-        return lst
-    step = len(lst) / n
-    return [lst[int(i * step)] for i in range(n)]
-
-
 def to_datetime(d: date):
     return datetime(year=d.year, month=d.month, day=d.day, hour=0, tzinfo=timezone.utc)
 
@@ -106,7 +98,7 @@ def detector_panel():
         st.warning(f"No cusum steps found for ASN {selected_asn}")
         return
 
-    st.altair_chart(make_cusums_chart(sample(chart_steps, 1000), block_type))
+    st.altair_chart(make_cusums_chart(chart_steps, block_type))
 
     if asns:
         df = pd.DataFrame({"ASN": list(asns.keys()), "total": list(asns.values())})


### PR DESCRIPTION
This PR adds a streamlit web panel to debug and diagnose events from the event detector. 

With this panel you can re-run the detector algorithm for any given input and check the results immediately. It will plot the cusums using an interactive Altair chart. 

You can also filter the cusums by `probe_asn` and `block_type`. 

It adds a new command to the `oonipipeline` CLI, the `oonipipeline events-panel` command to start the web server

Note that Streamlit is not a standard dependency, it's bundled with the `analysis` dependencies  

The clickhouse URL parameter can be specified in the left side panel, it defaults to localhost

Some screenshots: 

<img width="1872" height="833" alt="image" src="https://github.com/user-attachments/assets/f2f686ed-6821-43b4-9538-4b43390743bb" />
<img width="1835" height="345" alt="image" src="https://github.com/user-attachments/assets/b7e5c9c7-8fac-4157-b0d4-6a9a9604de00" />
