### PR TITLE
Evidence fix

### DIFF
--- a/docs/migration-notes.md
+++ b/docs/migration-notes.md
@@ -204,3 +204,40 @@ ALTER TABLE obs_web  ON CLUSTER oonidata_cluster                DROP COLUMN IF E
 ALTER TABLE obs_http_middlebox ON CLUSTER oonidata_cluster      DROP COLUMN IF EXISTS `probe_id`;
 ALTER TABLE analysis_web_measurement ON CLUSTER oonidata_cluster DROP COLUMN IF EXISTS `probe_id`;
 ```
+
+## 4. Reprocess `top_*_rule_id`
+
+**Introduced by:** "Rank the top rule on evidence before score"
+
+### Background
+
+`top_*_rule_id` was `argMax(rule_id, blocked)`. On a measurement that is not
+blocked the key is 0 on every row, so `argMax` kept whichever row it saw first.
+Every web_connectivity measurement carries one row per resolved IP plus one per
+redirect hop, and the redirect rows hold only HTTP, so they score `no_tls_data`
+and were winning that tie. The recorded values are wrong for a large share of
+rows, skewed toward the `no_*_data` ids.
+
+No DDL: the columns and their types are unchanged, only the expression filling
+them. Nothing reads these columns yet, so the reprocess can run behind the live
+pipeline.
+
+### Verify
+
+`no_*_data` should now appear only where the measurement genuinely had no data
+at that layer:
+
+```sql
+SELECT top_tls_rule_id, count() AS n,
+       countIf(greatest(tls_ok_max, tls_blocked_max, tls_down_max) > 0) AS with_verdict
+FROM analysis_web_measurement
+WHERE measurement_start_time > now() - INTERVAL 1 DAY
+GROUP BY top_tls_rule_id ORDER BY n DESC;
+```
+
+Any `no_*_data` row with `with_verdict > 0` means a row carrying no data still
+outranked one that did, so the evidence levels in `analysis/rules.py` are wrong.
+
+### Rollback
+
+Revert the code. Both versions write valid ids from the same vocabulary.

--- a/oonipipeline/src/oonipipeline/analysis/rules.py
+++ b/oonipipeline/src/oonipipeline/analysis/rules.py
@@ -1,31 +1,33 @@
 """
 The fuzzy-logic rule set used to score web observations.
 
-Previously these rules lived as literal ``multiIf`` cascades inside the analysis
-query's f-string, which had two consequences:
+Previously these rules lived as literal ``multiIf`` cascades inside the analysis query's f-string,
+which had two consequences:
 
-1. The only way to exercise a rule was to stand up ClickHouse, write a fixture
-   measurement and run the whole query. The rules themselves had no unit tests.
-2. The output recorded *what score* a row got but not *which rule produced it*,
-   so the distribution of rule firings was unknowable, weights could not be
-   attributed to outcomes, and re-scoring required reprocessing observations.
+1. The only way to exercise a rule was to stand up ClickHouse, write a fixture measurement and run
+    the whole query. The rules themselves had no unit tests.
+2. The output recorded *what score* a row got but not *which rule produced it*, so the distribution
+    of rule firings was unknowable, weights could not be attributed to outcomes, and re-scoring
+    required reprocessing observations.
 
-Representing them as data fixes both. The SQL is generated from the tables
-below, so the outcome cascade and the rule-id cascade are guaranteed to share
-the same conditions in the same order — a row's ``*_rule_id`` always names the
-rule that produced its score. The semantics of existing rules should not be changed, but one should rather
-create a new `rule_id` with the new semantics.
+Representing them as data fixes both. The SQL is generated from the tables below, so the outcome
+cascade and the rule-id cascade are guaranteed to share the same conditions in the same order — a
+row's ``*_rule_id`` always names the rule that produced its score. The semantics of existing rules
+should not be changed, but one should rather create a new `rule_id` with the new semantics.
 
-Rule ordering is significant: ``multiIf`` takes the first match, so a rule only
-fires when every rule above it did not. This is a decision tree whose leaves are
-hand-set, and the conditions are not mutually exclusive on their own.
+Rule ordering is significant: ``multiIf`` takes the first match, so a rule only fires when every
+rule above it did not. This is a decision tree whose leaves are hand-set, and the conditions are not
+mutually exclusive on their own.
 
-Outcome triples are ``(blocked, down, ok)``. They do not all sum to 1 —
-``answer_matches_ctrl`` sums to 0.9 and the masking rules sum to 0. That 0 is
-overloaded: it covers "no observation here", "observed but discarded" and
-"observed, nothing wrong" alike. Each rule therefore also carries an
-``Evidence`` level saying which of those it means, so aggregates do not have to
-infer it from the numbers. Read the level, never ``blocked == 0``.
+Outcome triples are ``(blocked, down, ok)``. They do not all sum to 1 necessarily.
+Masking rules sum to 0. That 0 is overloaded: it covers "no observation here", "observed but
+discarded" and "observed, nothing wrong" alike.
+
+Each rule therefore also carries an ``Evidence`` level saying which of those it means, so aggregates
+do not have to infer it from the numbers. Read the level, never ``blocked == 0``.
+
+TODO(art): the Evidence label carries with it a similar meaning to the Masking rules and should
+eventually be consolidated.
 """
 
 from dataclasses import dataclass
@@ -430,16 +432,7 @@ def render_top_rule_argmax(layer: str) -> str:
     unblocked measurement, which is nearly all of them, and the winner then
     comes down to row order.
 
-    So rank on evidence first, and only then on blocked. Ties on both are
-    broken by rule_id, which is arbitrary but stable — the replay determinism
-    the versioned-inputs work needs cannot be built on a coin flip.
-
-    Deliberately not ranked on `down` and `ok`: lexicographic ordering across
-    the triple only makes sense while the components are hand-set constants in
-    [0, 1]. When they become fitted log-likelihood ratios, `blocked` stays the
-    component `*_blocked_max` reports and argMax over it stays coherent with
-    max over it, while evidence and rule_id are unaffected. This expression
-    should survive that change untouched.
+    So rank on evidence first, and only then on blocked.
     """
     return (
         f"argMax({layer}_rule_id, ({layer}_evidence, {layer}_blocked, "

--- a/oonipipeline/src/oonipipeline/analysis/rules.py
+++ b/oonipipeline/src/oonipipeline/analysis/rules.py
@@ -20,17 +20,35 @@ Rule ordering is significant: ``multiIf`` takes the first match, so a rule only
 fires when every rule above it did not. This is a decision tree whose leaves are
 hand-set, and the conditions are not mutually exclusive on their own.
 
-Outcome triples are ``(blocked, down, ok)``. Note they do not all sum to 1 —
-``answer_matches_ctrl`` sums to 0.9 and the "no data" rules sum to 0. The 0 case
-is an overloaded mask meaning "this row has no observation at this layer, do not
-include it in aggregates", which is distinct from "observed but inconclusive"
-and should eventually become an explicit column rather than a sentinel triple.
+Outcome triples are ``(blocked, down, ok)``. They do not all sum to 1 —
+``answer_matches_ctrl`` sums to 0.9 and the masking rules sum to 0. That 0 is
+overloaded: it covers "no observation here", "observed but discarded" and
+"observed, nothing wrong" alike. Each rule therefore also carries an
+``Evidence`` level saying which of those it means, so aggregates do not have to
+infer it from the numbers. Read the level, never ``blocked == 0``.
 """
 
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import List, Tuple
 
 RULES_VERSION = 1
+
+
+class Evidence(IntEnum):
+    """How much a row has to say about its layer, independent of the score.
+
+    The triple cannot answer this: a rule scores (0, 0, 0) whether the layer
+    was never exercised, or was exercised and then discarded because an
+    earlier layer was untrustworthy. Both are "no verdict", but only the
+    second one names a cause, and neither is "we looked and found nothing
+    wrong". Ordered, so aggregates can prefer the row that saw the most.
+    """
+
+    NONE = 0  # layer produced no data on this row
+    DISCARDED = 1  # observed, but an earlier layer makes it uninterpretable
+    SCORED = 2  # observed and scored
+
 
 @dataclass(frozen=True)
 class Rule:
@@ -46,15 +64,17 @@ class Rule:
     down: float
     ok: float
     comment: str
+    evidence: Evidence = Evidence.SCORED
 
     @property
     def outcome(self) -> Tuple[float, float, float]:
         return (self.blocked, self.down, self.ok)
 
 
-# The rule id used when no condition matched. Shares the (0, 0, 0) outcome with
-# the explicit "no data" rules.
+# The rule id used when no condition matched. Nothing was established, so it
+# carries Evidence.NONE along with the (0, 0, 0) outcome.
 NO_MATCH_RULE_ID = "none"
+NO_MATCH_EVIDENCE = Evidence.NONE
 
 
 DNS_RULES: List[Rule] = [
@@ -68,6 +88,7 @@ DNS_RULES: List[Rule] = [
             "Row has no DNS data attached, most likely an HTTP(s)-only "
             "observation. Masked out of aggregate analysis."
         ),
+        evidence=Evidence.NONE,
     ),
     Rule(
         rule_id="country_consistent_blockpage",
@@ -188,6 +209,7 @@ TCP_RULES: List[Rule] = [
         down=0.0,
         ok=0.0,
         comment="Row has no TCP data attached. Masked out of aggregate analysis.",
+        evidence=Evidence.NONE,
     ),
     Rule(
         rule_id="connect_ok",
@@ -207,6 +229,7 @@ TCP_RULES: List[Rule] = [
             "Failure against an IPv6 target while IPv6 is failing broadly for "
             "this report_id — the probe most likely has broken IPv6. Masked."
         ),
+        evidence=Evidence.DISCARDED,
     ),
     Rule(
         rule_id="failure_ctrl_ok",
@@ -231,6 +254,7 @@ TCP_RULES: List[Rule] = [
             # TODO(art): this sits below connect_ok, so a successful connection
             # to a blockpage address is still scored as OK. Is that right?
         ),
+        evidence=Evidence.DISCARDED,
     ),
     Rule(
         rule_id="failure_ctrl_also_failing",
@@ -259,6 +283,7 @@ TLS_RULES: List[Rule] = [
         down=0.0,
         ok=0.0,
         comment="Row has no TLS data attached. Masked out of aggregate analysis.",
+        evidence=Evidence.NONE,
     ),
     Rule(
         rule_id="certificate_valid",
@@ -305,6 +330,7 @@ TLS_RULES: List[Rule] = [
         down=0.0,
         ok=0.0,
         comment="DNS was not trustworthy, so this result cannot be either. Masked.",
+        evidence=Evidence.DISCARDED,
     ),
     Rule(
         rule_id="tcp_blocked",
@@ -316,6 +342,7 @@ TLS_RULES: List[Rule] = [
             "TCP analysis says this address is blocked, so the TLS result is "
             "downstream of that. Masked."
         ),
+        evidence=Evidence.DISCARDED,
     ),
     Rule(
         rule_id="failure_ctrl_also_failing",
@@ -374,3 +401,47 @@ def render_rule_id_multiif(rules: List[Rule]) -> str:
     parts.append(_indent(f"'{NO_MATCH_RULE_ID}'"))
     parts.append(_indent(")", level=4))
     return "\n".join(parts)
+
+
+def render_evidence_multiif(rules: List[Rule]) -> str:
+    """
+    Render the Evidence cascade for a layer.
+
+    Same conditions in the same order as the other two cascades, so a row's
+    evidence level is the one belonging to the rule that scored it.
+    """
+    parts = ["multiIf("]
+    for rule in rules:
+        parts.append(_indent(f"{rule.condition},"))
+        parts.append(_indent(f"{int(rule.evidence)},"))
+    parts.append(_indent(f"{int(NO_MATCH_EVIDENCE)}"))
+    parts.append(_indent(")", level=4))
+    return "\n".join(parts)
+
+
+def render_top_rule_argmax(layer: str) -> str:
+    """
+    Render the aggregate picking the rule that drove a measurement's verdict.
+
+    A measurement has one row per resolved IP plus one per redirect hop, and
+    the redirect rows carry only HTTP, so at the DNS/TCP/TLS layers they score
+    Evidence.NONE. Ranking those rows against real observations is what has to
+    be avoided: `argMax(rule_id, blocked)` alone ties them at 0 on every
+    unblocked measurement, which is nearly all of them, and the winner then
+    comes down to row order.
+
+    So rank on evidence first, and only then on blocked. Ties on both are
+    broken by rule_id, which is arbitrary but stable — the replay determinism
+    the versioned-inputs work needs cannot be built on a coin flip.
+
+    Deliberately not ranked on `down` and `ok`: lexicographic ordering across
+    the triple only makes sense while the components are hand-set constants in
+    [0, 1]. When they become fitted log-likelihood ratios, `blocked` stays the
+    component `*_blocked_max` reports and argMax over it stays coherent with
+    max over it, while evidence and rule_id are unaffected. This expression
+    should survive that change untouched.
+    """
+    return (
+        f"argMax({layer}_rule_id, ({layer}_evidence, {layer}_blocked, "
+        f"{layer}_rule_id)) as top_{layer}_rule_id"
+    )

--- a/oonipipeline/src/oonipipeline/analysis/web_analysis.py
+++ b/oonipipeline/src/oonipipeline/analysis/web_analysis.py
@@ -8,8 +8,10 @@ from .rules import (
     DNS_RULES,
     TCP_RULES,
     TLS_RULES,
+    render_evidence_multiif,
     render_outcome_multiif,
     render_rule_id_multiif,
+    render_top_rule_argmax,
 )
 
 log = logging.getLogger(__name__)
@@ -121,17 +123,22 @@ def format_query_analysis_web_fuzzy_logic(
         AND has(expected_countries, probe_cc) as dns_blocking_country_consistent,
 
     -- Possibility distributions of states (blocking, down, ok). The rule set and
-    -- its weights live in analysis/rules.py; the cascade below is generated from
-    -- there, as is the matching *_rule_id cascade, so a row's rule id always
-    -- names the rule that produced its score.
+    -- its weights live in analysis/rules.py; all three cascades below are
+    -- generated from there off the same conditions in the same order, so a row's
+    -- rule id and evidence level always belong to the rule that scored it.
+    -- *_evidence says whether the layer produced data at all, which the (0, 0, 0)
+    -- outcome cannot distinguish from a clean result.
     {render_outcome_multiif(DNS_RULES)} as dns_outcome,
     {render_rule_id_multiif(DNS_RULES)} as dns_rule_id,
+    {render_evidence_multiif(DNS_RULES)} as dns_evidence,
 
     {render_outcome_multiif(TCP_RULES)} as tcp_outcome,
     {render_rule_id_multiif(TCP_RULES)} as tcp_rule_id,
+    {render_evidence_multiif(TCP_RULES)} as tcp_evidence,
 
     {render_outcome_multiif(TLS_RULES)} as tls_outcome,
     {render_rule_id_multiif(TLS_RULES)} as tls_rule_id,
+    {render_evidence_multiif(TLS_RULES)} as tls_evidence,
 
     ip,
     ip_asn,
@@ -194,12 +201,12 @@ def format_query_analysis_web_fuzzy_logic(
     max(tls_down) as tls_down_max,
     max(tls_ok) as tls_ok_max,
 
-    -- The rule that drove this measurement's headline score. argMax over the
-    -- blocked possibility rather than anyHeavy, so the id explains *_blocked_max
-    -- specifically. Ties (e.g. all-zero rows) resolve arbitrarily.
-    argMax(dns_rule_id, dns_blocked) as top_dns_rule_id,
-    argMax(tcp_rule_id, tcp_blocked) as top_tcp_rule_id,
-    argMax(tls_rule_id, tls_blocked) as top_tls_rule_id,
+    -- The rule that drove this measurement's verdict, ranked so that the rows
+    -- carrying no data for a layer cannot outrank the rows that do. See
+    -- render_top_rule_argmax.
+    {render_top_rule_argmax("dns")},
+    {render_top_rule_argmax("tcp")},
+    {render_top_rule_argmax("tls")},
 
     -- Constant within a measurement, so it rides along in the GROUP BY rather
     -- than needing an aggregate.

--- a/oonipipeline/tests/test_rules.py
+++ b/oonipipeline/tests/test_rules.py
@@ -13,11 +13,15 @@ import pytest
 from oonipipeline.analysis.rules import (
     DNS_RULES,
     LAYER_RULES,
+    NO_MATCH_EVIDENCE,
     NO_MATCH_RULE_ID,
     TCP_RULES,
     TLS_RULES,
+    Evidence,
+    render_evidence_multiif,
     render_outcome_multiif,
     render_rule_id_multiif,
+    render_top_rule_argmax,
 )
 from oonipipeline.analysis.web_analysis import format_query_analysis_web_fuzzy_logic
 
@@ -205,3 +209,84 @@ def test_generated_query_select_list_matches_table_column_count():
         f"analysis_web_measurement has {len(table_columns)}: "
         f"aliases={aliases} table={table_columns}"
     )
+
+
+# --------------------------------------------------------------------- evidence
+
+@ALL_LAYERS
+def test_evidence_agrees_with_the_outcome_triple(layer, rules):
+    """A scored rule must say something; a masked rule must not."""
+    for rule in rules:
+        if rule.evidence is Evidence.SCORED:
+            assert rule.outcome != (0.0, 0.0, 0.0), (
+                f"{layer}/{rule.rule_id} claims to be scored but is all zeros")
+        else:
+            assert rule.outcome == (0.0, 0.0, 0.0), (
+                f"{layer}/{rule.rule_id} is masked but scores {rule.outcome}")
+
+
+@ALL_LAYERS
+def test_every_layer_has_a_no_data_rule(layer, rules):
+    """Without one, HTTP-only rows fall through to a scoring rule."""
+    assert [r for r in rules if r.evidence is Evidence.NONE], layer
+
+
+@ALL_LAYERS
+def test_evidence_cascade_matches_the_others(layer, rules):
+    sql = render_evidence_multiif(rules)
+    levels = re.findall(r"^\s*(\d),?\s*$", sql, re.MULTILINE)
+    assert levels == [str(int(r.evidence)) for r in rules] + [
+        str(int(NO_MATCH_EVIDENCE))
+    ]
+    for rule in rules:
+        assert rule.condition in sql
+
+
+# --------------------------------------------------------------- the top rule
+
+def _rank(rule):
+    """The ordering render_top_rule_argmax generates, evaluated in Python."""
+    return (int(rule.evidence), rule.blocked, rule.rule_id)
+
+
+@ALL_LAYERS
+def test_rows_with_no_data_never_outrank_rows_with_data(layer, rules):
+    """The reported regression: an unblocked measurement still carries
+    HTTP-only rows, and those were winning the tie for top_*_rule_id."""
+    absent = [r for r in rules if r.evidence is Evidence.NONE]
+    present = [r for r in rules if r.evidence is not Evidence.NONE]
+    for a in absent:
+        for p in present:
+            assert _rank(p) > _rank(a), f"{layer}: {a.rule_id} beats {p.rule_id}"
+
+
+@ALL_LAYERS
+def test_discarded_rows_lose_to_scored_ones_but_beat_empty_ones(layer, rules):
+    """Discarding a result because DNS was untrusted is worth reporting, but
+    only when nothing better was observed."""
+    for rule in rules:
+        if rule.evidence is not Evidence.DISCARDED:
+            continue
+        for other in rules:
+            if other.evidence is Evidence.SCORED:
+                assert _rank(other) > _rank(rule)
+            elif other.evidence is Evidence.NONE:
+                assert _rank(rule) > _rank(other)
+
+
+@ALL_LAYERS
+def test_top_rule_ranking_is_total(layer, rules):
+    """No two rules may tie, or the winner depends on row order again."""
+    ranks = [_rank(r) for r in rules]
+    assert len(set(ranks)) == len(ranks)
+
+
+@ALL_LAYERS
+def test_top_rule_does_not_rank_on_down_or_ok(layer, rules):
+    """Lexicographic ordering across the triple holds only while the weights
+    are hand-set constants in [0, 1]. Ranking on blocked alone survives the
+    move to fitted log-likelihood ratios."""
+    sql = render_top_rule_argmax(layer)
+    assert f"{layer}_down" not in sql
+    assert f"{layer}_ok" not in sql
+    assert f"({layer}_evidence, {layer}_blocked, {layer}_rule_id)" in sql


### PR DESCRIPTION
top_*_rule_id was argMax(rule_id, blocked). On any measurement that isn't blocked the key is 0 on every row, so argMax kept whichever row it saw first. Every web_connectivity measurement carries one row per resolved IP plus one per redirect hop, and the redirect rows hold only HTTP, so they score no_tls_data and were winning that tie often enough to top the rule distribution. Reported against 20260803121332.892279_CA_webconnectivity_c4a3abc73d6a1985, which has two valid 4chan.org certificates and two redirect hops.

The reason the aggregate could not tell them apart is that (0, 0, 0) is overloaded, which ontology.md §6.2 already flags: it covers "no data here", "observed but discarded because DNS was untrusted" and, near enough, "observed and clean". So give each rule an explicit Evidence level (NONE, DISCARDED, SCORED) and rank on that first, then on blocked, then on rule_id for determinism. This is the "explicit column rather than a sentinel triple" the rules.py docstring was asking for; it is computed in the query, not persisted, so there is no DDL.

Deliberately not ranked on down and ok. Lexicographic ordering across the triple only means anything while the components are hand-set constants in [0, 1]; once they are fitted log-likelihood ratios, signed and unbounded, a strong "ok" would sort below a masked row and the fix would invert silently. Ranking on blocked alone keeps the id explaining *_blocked_max under any encoding, and evidence and rule_id are independent of it — the expression should survive that change untouched.

Verified with clickhouse local by feeding each scenario through the generated expression in both row orders: three of five were order-dependent before (including the reported one), none are now. The tests assert the ordering is total and that no-data rules cannot outrank rules that saw something, rather than pinning the SQL text.