### PR TITLE
Fix bug in DNS analysis for web_connectivity 0.5

### DIFF
--- a/oonipipeline/src/oonipipeline/analysis/web_analysis.py
+++ b/oonipipeline/src/oonipipeline/analysis/web_analysis.py
@@ -214,8 +214,8 @@ def format_query_analysis_web_fuzzy_logic(
 
     FROM (
         WITH
-        position(ip, '.') = 0 as ip_is_v6,
-        position(ip, '.') != 0 as ip_is_v4
+        isIPv4String(ip) as ip_is_v4,
+        isIPv6String(ip) as ip_is_v6
 
         SELECT
         measurement_uid,
@@ -238,9 +238,9 @@ def format_query_analysis_web_fuzzy_logic(
         -- We limit this to only the system resolver
         -- TODO: in order to fully support web_connectivity 0.5 we should ideally
         -- parse this as well.
-        groupArrayIf(dns_answer, dns_engine IN ('getaddrinfo', 'system')) over (partition by measurement_uid, hostname, ip_is_v6) as dns_answers,
-        groupArrayIf(ip_asn, dns_engine IN ('getaddrinfo', 'system')) over (partition by measurement_uid, hostname, ip_is_v6) as dns_answers_asns,
-        maxIf(ip_is_bogon, dns_engine IN ('getaddrinfo', 'system')) over (partition by measurement_uid, hostname, ip_is_v6) as dns_answers_contain_bogon,
+        groupArrayIf(dns_answer, dns_engine IN ('getaddrinfo', 'system') AND (ip_is_v6 OR ip_is_v4)) over (partition by measurement_uid, hostname, ip_is_v6) as dns_answers,
+        groupArrayIf(ip_asn, dns_engine IN ('getaddrinfo', 'system') AND (ip_is_v6 OR ip_is_v4)) over (partition by measurement_uid, hostname, ip_is_v6) as dns_answers_asns,
+        maxIf(ip_is_bogon, dns_engine IN ('getaddrinfo', 'system') AND (ip_is_v6 OR ip_is_v4)) over (partition by measurement_uid, hostname, ip_is_v6) as dns_answers_contain_bogon,
 
         countIf(ip_asn IN %(cloud_provider_asns)s) over (partition by measurement_uid) as dns_answers_cloud,
 

--- a/oonipipeline/tests/_fixtures.py
+++ b/oonipipeline/tests/_fixtures.py
@@ -47,6 +47,7 @@ SAMPLE_MEASUREMENTS = [
     "20250125135854.612046_AU_webconnectivity_45560dd5efe1035c",  # Scrubbed IP in DNS answer
     "20250201172431.190360_CZ_signal_ef68029a5fff6e29",  # Scrubbed IP address in test_keys
     "20260730100745.046370_IN_webconnectivity_35dfecc6616656ee",  # wc 0.5 with control-only resolved addresses
+    "20260820134136.956850_IR_webconnectivity_849483829bc121b7", # wc 0.5 with mismatching answers, which are TLS consistent
 ]
 
 SAMPLE_POSTCANS = ["2024030100_AM_webconnectivity.n1.0.tar.gz"]

--- a/oonipipeline/tests/test_analysis.py
+++ b/oonipipeline/tests/test_analysis.py
@@ -306,6 +306,18 @@ def test_website_web_analysis_blocked_inconsistent_country(measurements, netinfo
     assert analysis["dns_blocked_max"] > 0.5
     assert analysis["top_dns_failure"] == None
 
+def test_website_web_analysis_wc05_ok_dns_tls_consistent(measurements, netinfodb, db):
+    measurement_uid = "20260820134136.956850_IR_webconnectivity_849483829bc121b7"
+    analysis = perform_analysis(
+        db=db,
+        netinfodb=netinfodb,
+        measurements=measurements,
+        measurement_uid=measurement_uid,
+    )
+    print(analysis)
+    assert analysis["dns_ok_max"] > 0.5
+    assert analysis["dns_blocked_max"] < 0.5
+    assert analysis["top_dns_failure"] == None
 
 # --------------------------------------------------------------------------
 # web_connectivity 0.5 QA fixtures


### PR DESCRIPTION
In web_connectivity 0.5 the DNS analysis includes also the CNAME record pointer. Since the CNAME record pointer is considered as an IP inside of the analysis, it will attempt to find TLS consistency for it. This will always fail since these are not looked up in the test helper, nor used to establish TLS consistency.

The fix is filter out DNS answers which are only IPv4 or IPv6 addresses.